### PR TITLE
Bidirectional peers: generalized identity, lease-based presence, scoped broadcast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Phase 2 的 `switchboard-role.txt` 已刪除（靜態 config signal 不再需要
 
 ### Troubleshooting
 
-- **Session 沒被自動喚醒** → 確認 Claude 在第一輪有呼叫 `register(role, cc_session_id)`；DB 裡 `SELECT * FROM sessions WHERE cc_session_id = 'xxx'` 應該看到 active row
+- **Session 沒被自動喚醒** → 確認 Claude 在第一輪有呼叫 `register(role, cc_session_id)`；DB 裡 `SELECT * FROM sessions WHERE client_kind = 'claude_code' AND client_session_id = 'xxx'` 應該看到 active row
 - **Role collision** → 另一個 active session 正在用同樣的 role。換名字或等對方 disconnect
 - **Orphan poller** → shim 啟動時往上 walk parent chain 找 `claude.exe`（或 `node.exe`），用它的 pid 當 liveness target，而**不是** immediate parent（那是 bash.exe，會 wait shim child 結束所以永遠活）。Claude Code 死 → shim 下個 loop tick 檢查 claude.exe pid 失敗 → exit 0。舊版 `bun poller.ts` 同樣有 parent-pid check，失靈時 fallback 24 小時 TTL
 - **Shim 堆積（同一 cc_session_id 多個 shim 同時 polling）** → 每個 turn Stop hook 都會 fire 新 shim；新 shim 啟動時讀 `<state_dir>/switchboard-shim-<cc_session_id>.lock`，殺掉舊 shim 後寫入自己 pid。所以每個 cc 最多一個 shim 活著

--- a/README.md
+++ b/README.md
@@ -150,12 +150,21 @@ Each tool takes JSON arguments; responses are JSON inside a `content[0].text` te
 | `register` | `role?`, `cc_session_id?` | `{session_id, alias, anonymous}` |
 | `set_alias` | `alias` | `{old_alias, new_alias}` |
 | `send` | `to`, `message` | `{message_id, delivered_notification}` |
-| `broadcast` | `message` | `{broadcast_id, recipient_count, notified_count}` |
+| `broadcast` | `message`, `scope?` | `{broadcast_id, recipient_count, notified_count}` |
 | `read_messages` | — | `{messages: [...]}` |
 | `list_sessions` | — | `[{session_id, alias, online, created_at, last_activity}, ...]` |
 | `recall` | `message_id` | `{recalled_count}` |
+| `unregister` | — | `{status, released_alias}` — `status` is `released`, `stale_ignored` (a newer generation re-registered this identity; nothing was released), or `already_offline` |
 
-`to` accepts either an alias or a session UUID. `delivered_notification` is true when the recipient has either a live `/poll` long-poll *or* an active `/monitor` subscription — the in-memory polling set covers both wake paths. It's an honest *"the recipient will notice this without user intervention"* signal, not just *"the bytes hit the socket."*
+`to` accepts either an alias or a session UUID. `delivered_notification` is true when the message was pushed over a live MCP connection *or* the recipient is online per the lease/polling predicate below. It's an honest *"the recipient will notice this without user intervention"* signal, not just *"the bytes hit the socket."*
+
+`broadcast` accepts an optional `scope` (default `all`, preserving legacy calls):
+
+- `all` — every active session except the sender
+- `same_kind` — sessions sharing the sender's `client_kind`, across cwds
+- `same_cwd` — sessions sharing the sender's registered `cwd`, across kinds; if either side's cwd is NULL there is no match
+
+Codex-kind recipients are only written to when they are online at insert time — offline Codex peers accumulate **no** broadcast backlog. Claude Code and external recipients keep durable offline mailboxes. `recipient_count` and `notified_count` are both derived from the same filtered recipient set.
 
 ## HTTP endpoints
 
@@ -165,7 +174,22 @@ Each tool takes JSON arguments; responses are JSON inside a `content[0].text` te
   `{ "to": "<alias-or-session-id>", "message": "...", "from": "codex" }`.
   `from` is optional and defaults to `codex`. Returns
   `{message_id, delivered_notification}`.
-- `GET /poll?cc_session_id=<uuid>&timeout_s=<1..250>` — long-poll for unread mail. Returns JSON:
+- `POST /register` — HTTP registration for peers that hold no MCP connection
+  (e.g. the codex-bridge waker). JSON body:
+  `{ "alias": "...", "client_kind": "claude_code"|"codex"|"external", "client_session_id": "<stable-instance-id>", "cwd": "/abs/path" }`.
+  Idempotent upsert keyed on `(client_kind, client_session_id)`; re-registering
+  reactivates the row and bumps its generation. Returns
+  `{session_id, alias, generation}`; 400 on validation errors, 409 on alias
+  collision.
+- `POST /unregister` — graceful peer sign-off. JSON body:
+  `{ "client_kind": ..., "client_session_id": ..., "generation": <int> }`.
+  The generation must match the current row — a delayed unregister from an
+  older instance cannot release a newer one (409). Returns
+  `{status: "released" | "already_released"}`, 404 when unknown.
+- `GET /poll?client_kind=<kind>&client_session_id=<id>&timeout_s=<1..250>` —
+  canonical long-poll for unread mail. Every call also renews the caller's
+  lease (`last_seen_at`). The legacy form `?cc_session_id=<uuid>` remains
+  supported as an alias for `client_kind=claude_code`. Returns JSON:
   - `{status: "unread", count, alias, message}` — Stop-hook shim exits 2
   - `{status: "timeout"}` — shim re-dials
   - `{status: "no-session"}` — alias is gone; shim exits 0
@@ -222,10 +246,41 @@ The `SessionStart` hook injects the Claude Code session id into each session, an
 
 Without `cc_session_id`, registration still succeeds (Phase 1 fallback) but every call creates a fresh row.
 
+## Bidirectional peers: identity, generation, lease
+
+Sessions are generalized beyond Claude Code:
+
+- **`client_kind`** namespaces identities: `claude_code`, `codex`, `external`.
+  The unique-identity index is `(client_kind, client_session_id)`, so a Codex
+  instance id can never collide with a Claude Code session id.
+- **Stable identity, not thread identity.** A peer's `client_session_id` is a
+  durable instance UUID (for the Codex waker it persists in
+  `~/.codex/waker-instance-id`). Conversation thread ids are client-side state
+  and never enter the database.
+- **Generation guard.** Every re-register bumps the row's generation. All
+  release paths — HTTP `/unregister`, the MCP `unregister` tool, and MCP
+  transport cleanup on disconnect — are generation-checked, so a stale
+  instance's late sign-off can never evict the live one.
+- **Lease-based online.** `online = live MCP connection OR an active
+  /poll(/monitor) wait OR a valid lease`. Each `/poll` renews `last_seen_at`;
+  the lease TTL is five minutes (one 250 s long-poll plus reconnect slack).
+  Graceful exits unregister by generation; crashes simply let the lease
+  expire. Message truth remains `read_at` — wakes are best-effort doorbells.
+
+**Known limitation (tracked follow-up):** Switchboard does not yet expose a
+generation/identity-guarded HTTP endpoint for peers to read and mark their
+messages. The companion Codex waker (codex-bridge) therefore degrades to a
+deduplicated unread notification and does not read SQLite directly.
+
 ## Retention & cleanup
 
 - Messages marked read are deleted after 7 days.
-- Sessions that look orphaned — no active MCP connection *and* no activity for 5+ minutes — are released on the next retention tick (every minute), freeing their aliases.
+- Sessions whose lease has been stale for over 24 hours — no MCP connection,
+  no polling, no lease renewal — are released by the retention sweep (every
+  2 hours), freeing their aliases. A crashed session that never fired
+  `transport.onclose` can therefore hold its alias for up to ~26 hours; the
+  same identity can always reclaim its row immediately via idempotent
+  re-register.
 - The Stop-hook shim self-terminates when its Claude Code parent dies, so no orphan poller outlives its session. Transient daemon errors (restart, TCP blip, 5xx) back off and retry rather than exiting, so a brief outage does not leave the session unreachable until the next Claude Code turn. The legacy `bun poller.ts` fallback does the same parent-pid check via `process.kill(ppid, 0)`.
 
 ## Security
@@ -247,11 +302,12 @@ bunx tsc --noEmit        # type check
 
 ```
 main.ts                  # daemon entry
-server.ts                # MCP tool handlers + /poll + /monitor + Bun.serve wiring
-db.ts                    # SQLite helpers (sessions, messages, retention queries)
-schema.sql               # DB schema with Phase 2.5 columns
+server.ts                # MCP tool handlers + /register + /unregister + /poll + /monitor + Bun.serve wiring
+db.ts                    # SQLite helpers (sessions, messages, generation-aware upsert, retention queries)
+schema.sql               # DB schema (client_kind / client_session_id / cwd / last_seen_at / generation / reply_to)
+online.ts                # shared online predicate: MCP connection OR polling OR valid lease
 connections.ts           # in-memory ConnectionRegistry for push callbacks
-waiters.ts               # UnreadWaiterRegistry — shared by /poll and /monitor
+waiters.ts               # UnreadWaiterRegistry — kind-qualified, shared by /poll and /monitor
 retention.ts             # periodic expired-message + stale-session cleanup
 aliases.ts               # alias collision handling + target resolution
 poller.ts                # legacy bun-based Stop-hook poller (fallback)

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ The `while … sleep 5` wrapper auto-reconnects if the daemon restarts or the TC
 
 Trigger rules worth internalising:
 - A direct `send(to=you)` wakes you.
-- A `broadcast` that includes you (every non-released session except the sender) wakes you.
+- A `broadcast` wakes you only when its selected scope includes your session.
 - *Your own* `send` / `broadcast` does **not** wake you — the sender is excluded on the server side.
 - Other sessions' 1-to-1 traffic never leaks onto your stream.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -149,12 +149,21 @@ Role 名字挑一個能描述這個 session 在做什麼的（例如 `tools`、`
 | `register` | `role?`、`cc_session_id?` | `{session_id, alias, anonymous}` |
 | `set_alias` | `alias` | `{old_alias, new_alias}` |
 | `send` | `to`、`message` | `{message_id, delivered_notification}` |
-| `broadcast` | `message` | `{broadcast_id, recipient_count, notified_count}` |
+| `broadcast` | `message`、`scope?` | `{broadcast_id, recipient_count, notified_count}` |
 | `read_messages` | — | `{messages: [...]}` |
 | `list_sessions` | — | `[{session_id, alias, online, created_at, last_activity}, ...]` |
 | `recall` | `message_id` | `{recalled_count}` |
+| `unregister` | — | `{status, released_alias}`——`status` 為 `released`、`stale_ignored`（同一 identity 已被更新世代重新註冊，未釋放任何東西）或 `already_offline` |
 
-`to` 可以是 alias 或 session UUID。`delivered_notification` 只要收件人當下有 active 的 `/poll` long-poll *或* `/monitor` 訂閱就會回 true——in-memory 的 polling set 涵蓋兩條 wake path。這是誠實的「收件人不用人類介入也會注意到」訊號，而不是「bytes 有送到 socket」。
+`to` 可以是 alias 或 session UUID。`delivered_notification` 在訊息經由活的 MCP 連線推送成功、*或*收件人依下方 lease/polling 判定為在線時回 true。這是誠實的「收件人不用人類介入也會注意到」訊號，而不是「bytes 有送到 socket」。
+
+`broadcast` 可帶選填的 `scope`（預設 `all`，舊呼叫行為不變）：
+
+- `all`——除寄件人外的全部 active session
+- `same_kind`——與寄件人同 `client_kind`，跨 cwd
+- `same_cwd`——與寄件人註冊的 `cwd` 相同，跨 kind；任一方 cwd 為 NULL 即不匹配
+
+`client_kind` 為 codex 的收件人**只有在線時才寫入訊息列**——離線的 Codex peer 不累積任何廣播積壓；Claude Code 與 external 收件人維持離線也入列、上線再讀。`recipient_count` 與 `notified_count` 都以同一份過濾後的收件清單計算。
 
 ## HTTP endpoints
 
@@ -163,7 +172,17 @@ Role 名字挑一個能描述這個 session 在做什麼的（例如 `tools`、`
   codex-bridge 在背景 job 完成後通知 Claude Code。JSON body：
   `{ "to": "<alias-or-session-id>", "message": "...", "from": "codex" }`
  ；`from` 可省略，預設 `codex`。回傳 `{message_id, delivered_notification}`。
-- `GET /poll?cc_session_id=<uuid>&timeout_s=<1..250>` — long-poll 等待新訊息，回 JSON：
+- `POST /register` — 給不持 MCP 連線的 peer（例如 codex-bridge 的 waker）用的 HTTP 註冊。JSON body：
+  `{ "alias": "...", "client_kind": "claude_code"|"codex"|"external", "client_session_id": "<穩定的 instance id>", "cwd": "/絕對路徑" }`。
+  以 `(client_kind, client_session_id)` 冪等 upsert；重複註冊會重新啟用該列並遞增 generation。回傳
+  `{session_id, alias, generation}`；驗證錯誤回 400、alias 衝突回 409。
+- `POST /unregister` — peer 優雅下線。JSON body：
+  `{ "client_kind": ..., "client_session_id": ..., "generation": <int> }`。
+  generation 必須與現值相符——舊 instance 遲到的下線請求動不了新 instance（409）。回傳
+  `{status: "released" | "already_released"}`，查無此 identity 回 404。
+- `GET /poll?client_kind=<kind>&client_session_id=<id>&timeout_s=<1..250>` —
+  正式版 long-poll 等待新訊息，每次呼叫同時為呼叫者續租 lease（更新 `last_seen_at`）。
+  舊格式 `?cc_session_id=<uuid>` 仍支援，等同 `client_kind=claude_code`。回 JSON：
   - `{status: "unread", count, alias, message}` — Stop-hook shim 應 `exit 2`
   - `{status: "timeout"}` — shim 重新撥接
   - `{status: "no-session"}` — alias 消失；shim `exit 0`
@@ -220,10 +239,32 @@ Monitor({
 
 不帶 `cc_session_id` 也能 register（Phase 1 fallback），只是每次都建新 row。
 
+## 雙邊 peer：identity、generation、lease
+
+session 已一般化，不再是 Claude Code 專屬：
+
+- **`client_kind` 命名空間**：`claude_code`、`codex`、`external`。identity 唯一索引為
+  `(client_kind, client_session_id)`，Codex 的 instance id 永遠不會跟 Claude Code 的 session id 撞衫。
+- **穩定 identity，不是 thread identity**。peer 的 `client_session_id` 是持久的 instance UUID
+  （Codex waker 存在 `~/.codex/waker-instance-id`）；對話 thread id 屬 client 端狀態，絕不進資料庫。
+- **generation guard**：每次重新註冊遞增 generation。所有釋放路徑——HTTP `/unregister`、
+  MCP `unregister` 工具、MCP transport 斷線清理——都檢查 generation，舊 instance 遲到的
+  下線動作不可能誤殺活著的新 instance。
+- **lease 制 online**：`online = 活的 MCP 連線 OR 進行中的 /poll(/monitor) OR 有效 lease`。
+  每次 `/poll` 更新 `last_seen_at`；lease TTL 為 5 分鐘（涵蓋一次 250 秒 long-poll 加重連緩衝）。
+  優雅退出走 generation unregister；crash 就讓 lease 自然過期。訊息的真相永遠是
+  `read_at`——喚醒只是 best-effort 的門鈴。
+
+**已知限制（列管後續項目）**：Switchboard 尚未提供以 generation/identity 驗證身分的
+HTTP 讀信端點供 peer 讀取並標記自己的訊息。codex-bridge 的 Codex waker 因此降級為
+去重後的 unread 通知，且不直接讀 SQLite。
+
 ## 保留 & 清理
 
 - 已讀訊息 7 天後自動刪除。
-- 看起來孤兒的 session（沒 MCP 連線 *且* 5+ 分鐘沒活動）會在下一次保留 tick（每分鐘一次）被 release，alias 讓出。
+- lease 過期超過 24 小時的 session（沒 MCP 連線、沒 polling、沒續租）由保留巡檢
+  （每 2 小時一次）補蓋 released_at、讓出 alias。crash 且沒觸發 `transport.onclose` 的
+  session 因此最長可能占用 alias 約 26 小時；同一 identity 隨時可透過冪等重新註冊立即取回自己的列。
 - Stop-hook shim 偵測到 Claude Code parent 死了就自我了斷，不會留下 orphan poller。暫時性 daemon 錯誤（重啟、TCP 閃斷、5xx）會 backoff retry 而不退出，短暫 outage 不會讓 session 到下次 turn 才能接收訊息。舊版 `bun poller.ts` fallback 同樣用 `process.kill(ppid, 0)` 做 parent-pid check。
 
 ## 安全
@@ -245,11 +286,12 @@ bunx tsc --noEmit        # type check
 
 ```
 main.ts                  # daemon 入口
-server.ts                # MCP 工具 handler + /poll + /monitor + Bun.serve
-db.ts                    # SQLite helper（session、訊息、保留查詢）
-schema.sql               # Phase 2.5 欄位的 schema
+server.ts                # MCP 工具 handler + /register + /unregister + /poll + /monitor + Bun.serve
+db.ts                    # SQLite helper（session、訊息、generation-aware upsert、保留查詢）
+schema.sql               # schema（client_kind / client_session_id / cwd / last_seen_at / generation / reply_to）
+online.ts                # 共用 online 判定：MCP 連線 OR polling OR 有效 lease
 connections.ts           # in-memory ConnectionRegistry，管 push callback
-waiters.ts               # UnreadWaiterRegistry，/poll 和 /monitor 共用
+waiters.ts               # UnreadWaiterRegistry，kind-qualified，/poll 和 /monitor 共用
 retention.ts             # 定期清過期訊息 + 孤兒 session
 aliases.ts               # alias 碰撞處理 + 目標解析
 poller.ts                # 舊版 bun 實作的 Stop-hook poller（fallback）

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -223,7 +223,7 @@ Monitor({
 
 觸發規則值得內化：
 - 別人 `send(to=你)` 會喚醒你。
-- 別人 `broadcast`（包含你；也就是所有非 released 且非 sender 的 session）會喚醒你。
+- 別人的 `broadcast` 只有在所選 scope 包含你的 session 時才會喚醒你。
 - *你自己* 的 `send` / `broadcast` **不會**喚醒自己——server 端會排除 sender。
 - 別人之間的 1-to-1 不會洩進你的 stream。
 

--- a/connections.ts
+++ b/connections.ts
@@ -14,7 +14,8 @@ export class ConnectionRegistry {
     this.connections.set(session_id, callback)
   }
 
-  unregister(session_id: string): void {
+  unregister(session_id: string, callback?: PushCallback): void {
+    if (callback && this.connections.get(session_id) !== callback) return
     this.connections.delete(session_id)
   }
 
@@ -29,6 +30,9 @@ export class ConnectionRegistry {
       cb(payload)
       return true
     } catch (err) {
+      if (this.connections.get(session_id) === cb) {
+        this.connections.delete(session_id)
+      }
       process.stderr.write(`switchboard: push failed for ${session_id}: ${err}\n`)
       return false
     }

--- a/db.ts
+++ b/db.ts
@@ -293,6 +293,19 @@ export function releaseSession(db: Database, id: string): void {
   ).run(nowUtc(), id)
 }
 
+export function releaseSessionIfGeneration(
+  db: Database,
+  id: string,
+  generation: number,
+): boolean {
+  const result = db.query(
+    `UPDATE sessions
+     SET alias = NULL, released_at = ?
+     WHERE id = ? AND generation = ? AND released_at IS NULL`,
+  ).run(nowUtc(), id, generation)
+  return Number(result.changes) === 1
+}
+
 export function reactivateSession(db: Database, id: string, alias: string | null): void {
   // Clears released_at and restores alias so the row is "active" again.
   // Called when a cc_session_id reconnects to a previously released session.
@@ -303,6 +316,11 @@ export function reactivateSession(db: Database, id: string, alias: string | null
 
 export function updateLastActivity(db: Database, id: string): void {
   db.query('UPDATE sessions SET last_activity = ? WHERE id = ?')
+    .run(nowUtc(), id)
+}
+
+export function updateLastSeen(db: Database, id: string): void {
+  db.query('UPDATE sessions SET last_seen_at = ? WHERE id = ?')
     .run(nowUtc(), id)
 }
 
@@ -449,9 +467,8 @@ export function deleteExpiredMessages(db: Database): number {
 /**
  * Release sessions that look orphaned: alive in DB (released_at IS NULL) but
  * either (a) not currently connected to any transport, and (b) no activity
- * within staleThresholdMs. Both conditions must hold — the connection check
- * protects legitimately-idle live sessions, the time check protects against
- * registry leaks that might falsely list a dead transport as connected.
+ * within staleThresholdMs. The later of lease renewal and general activity is
+ * used, so a fresh re-register is not discarded because of an older lease.
  *
  * @param connectedIds session IDs currently present in ConnectionRegistry
  * @returns IDs of sessions that were released by this call
@@ -466,7 +483,11 @@ export function releaseStaleActiveSessions(
     .query<{ id: string }, [string]>(
       `SELECT id FROM sessions
        WHERE released_at IS NULL
-         AND last_activity < ?`,
+         AND CASE
+           WHEN last_seen_at IS NOT NULL AND last_seen_at > last_activity
+             THEN last_seen_at
+           ELSE last_activity
+         END < ?`,
     )
     .all(cutoff)
   const connected = new Set(connectedIds)

--- a/db.ts
+++ b/db.ts
@@ -376,6 +376,7 @@ export function markMessagesRead(db: Database, messageIds: string[]): void {
 
 export interface BroadcastInput {
   sender_id: string
+  recipient_ids: string[]
   content: string
 }
 
@@ -387,9 +388,6 @@ export interface BroadcastDbResult {
 
 export function insertBroadcast(db: Database, input: BroadcastInput): BroadcastDbResult {
   const broadcast_id = randomUUID()
-  const recipients = db.query<{ id: string }, [string]>(
-    'SELECT id FROM sessions WHERE id != ? AND released_at IS NULL'
-  ).all(input.sender_id)
 
   const now = nowUtc()
   const stmt = db.query(`
@@ -398,17 +396,17 @@ export function insertBroadcast(db: Database, input: BroadcastInput): BroadcastD
     )
     VALUES (?, ?, ?, ?, NULL, ?, ?, NULL)
   `)
-  const insertTx = db.transaction((rows: typeof recipients) => {
-    for (const r of rows) {
-      stmt.run(randomUUID(), input.sender_id, r.id, broadcast_id, input.content, now)
+  const insertTx = db.transaction((recipientIds: string[]) => {
+    for (const recipientId of recipientIds) {
+      stmt.run(randomUUID(), input.sender_id, recipientId, broadcast_id, input.content, now)
     }
   })
-  insertTx(recipients)
+  insertTx(input.recipient_ids)
 
   return {
     broadcast_id,
-    recipient_count: recipients.length,
-    recipient_ids: recipients.map((r) => r.id),
+    recipient_count: input.recipient_ids.length,
+    recipient_ids: input.recipient_ids,
   }
 }
 

--- a/db.ts
+++ b/db.ts
@@ -3,32 +3,77 @@ import { readFileSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { randomUUID } from 'crypto'
-import type { SessionRow, MessageRow } from './types'
+import type { ClientKind, SessionRow, MessageRow } from './types'
 import { nowUtc } from './time'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function tableExists(db: Database, table: string): boolean {
+  return db
+    .query<{ name: string }, [string]>(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+    )
+    .get(table) != null
+}
+
+function columnNames(db: Database, table: string): Set<string> {
+  return new Set(
+    db
+      .query<{ name: string }, []>(`PRAGMA table_info(${table})`)
+      .all()
+      .map((column) => column.name),
+  )
+}
+
+function migrateSchema(db: Database): void {
+  if (!tableExists(db, 'sessions')) return
+
+  db.transaction(() => {
+    const sessionColumns = columnNames(db, 'sessions')
+
+    if (sessionColumns.has('cc_session_id') && !sessionColumns.has('client_session_id')) {
+      db.exec('ALTER TABLE sessions RENAME COLUMN cc_session_id TO client_session_id')
+      sessionColumns.delete('cc_session_id')
+      sessionColumns.add('client_session_id')
+    }
+    if (!sessionColumns.has('client_session_id')) {
+      db.exec('ALTER TABLE sessions ADD COLUMN client_session_id TEXT')
+      sessionColumns.add('client_session_id')
+    }
+    if (!sessionColumns.has('client_kind')) {
+      db.exec(`ALTER TABLE sessions ADD COLUMN client_kind TEXT NOT NULL DEFAULT 'claude_code'`)
+    }
+    if (!sessionColumns.has('cwd')) {
+      db.exec('ALTER TABLE sessions ADD COLUMN cwd TEXT')
+    }
+    if (!sessionColumns.has('last_seen_at')) {
+      db.exec('ALTER TABLE sessions ADD COLUMN last_seen_at TEXT')
+    }
+    if (!sessionColumns.has('released_at')) {
+      db.exec('ALTER TABLE sessions ADD COLUMN released_at TEXT')
+    }
+
+    db.exec('DROP INDEX IF EXISTS idx_sessions_cc_session_id_active')
+    db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_client_identity_active
+      ON sessions(client_kind, client_session_id)
+      WHERE client_session_id IS NOT NULL AND released_at IS NULL
+    `)
+
+    if (tableExists(db, 'messages')) {
+      const messageColumns = columnNames(db, 'messages')
+      if (!messageColumns.has('reply_to')) {
+        db.exec('ALTER TABLE messages ADD COLUMN reply_to TEXT')
+      }
+    }
+  })()
+}
 
 export function openDatabase(path: string): Database {
   const db = new Database(path)
   db.exec('PRAGMA foreign_keys = ON')
   db.exec('PRAGMA journal_mode = WAL')
-
-  // Migration guard: if sessions table exists but missing Phase 2.5 columns,
-  // drop sessions + messages (they will be rebuilt from schema.sql).
-  const tableExists = db
-    .query<{ name: string }, [string]>(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
-    .get('sessions')
-  if (tableExists) {
-    const cols = db.query<{ name: string }, []>(`PRAGMA table_info(sessions)`).all()
-    const colNames = new Set(cols.map((c) => c.name))
-    const needsMigration = !colNames.has('cc_session_id') || !colNames.has('released_at')
-    if (needsMigration) {
-      db.transaction(() => {
-        db.exec(`DROP TABLE IF EXISTS messages`)
-        db.exec(`DROP TABLE IF EXISTS sessions`)
-      })()
-    }
-  }
+  migrateSchema(db)
 
   const schemaPath = join(__dirname, 'schema.sql')
   const schema = readFileSync(schemaPath, 'utf8')
@@ -40,28 +85,73 @@ export function createSession(
   db: Database,
   opts: { alias: string | null; cc_session_id?: string | null },
 ): string {
+  return createClientSession(db, {
+    alias: opts.alias,
+    client_kind: 'claude_code',
+    client_session_id: opts.cc_session_id,
+  })
+}
+
+export function createClientSession(
+  db: Database,
+  opts: {
+    alias: string | null
+    client_kind: ClientKind
+    client_session_id?: string | null
+    cwd?: string | null
+  },
+): string {
   const id = randomUUID()
   const now = nowUtc()
   db.query(`
-    INSERT INTO sessions (id, alias, cc_session_id, created_at, last_activity, released_at)
-    VALUES (?, ?, ?, ?, ?, NULL)
-  `).run(id, opts.alias, opts.cc_session_id ?? null, now, now)
+    INSERT INTO sessions (
+      id, alias, client_kind, client_session_id, cwd,
+      created_at, last_activity, last_seen_at, released_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+  `).run(
+    id,
+    opts.alias,
+    opts.client_kind,
+    opts.client_session_id ?? null,
+    opts.cwd ?? null,
+    now,
+    now,
+  )
   return id
 }
 
 export function findSessionById(db: Database, id: string): SessionRow | null {
   const row = db.query<SessionRow, [string]>(
-    'SELECT id, alias, cc_session_id, created_at, last_activity FROM sessions WHERE id = ?'
+    `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
+            last_activity, last_seen_at, released_at
+     FROM sessions
+     WHERE id = ?`,
   ).get(id)
   return row ?? null
 }
 
 export function findSessionByAlias(db: Database, alias: string): SessionRow | null {
   const row = db.query<SessionRow, [string]>(
-    `SELECT id, alias, cc_session_id, created_at, last_activity
+    `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
+            last_activity, last_seen_at, released_at
      FROM sessions
      WHERE alias = ? AND released_at IS NULL`,
   ).get(alias)
+  return row ?? null
+}
+
+export function findSessionByClientSessionId(
+  db: Database,
+  client_kind: ClientKind,
+  client_session_id: string,
+): SessionRow | null {
+  const row = db.query<SessionRow, [ClientKind, string]>(
+    `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
+            last_activity, last_seen_at, released_at
+     FROM sessions
+     WHERE client_kind = ? AND client_session_id = ? AND released_at IS NULL`,
+  ).get(client_kind, client_session_id)
   return row ?? null
 }
 
@@ -69,28 +159,32 @@ export function findSessionByCcSessionId(
   db: Database,
   cc_session_id: string,
 ): SessionRow | null {
-  const row = db.query<SessionRow, [string]>(
-    `SELECT id, alias, cc_session_id, created_at, last_activity
-     FROM sessions
-     WHERE cc_session_id = ? AND released_at IS NULL`,
-  ).get(cc_session_id)
-  return row ?? null
+  return findSessionByClientSessionId(db, 'claude_code', cc_session_id)
 }
 
 /**
  * Like findSessionByCcSessionId but also returns released rows.
  * Used by register to reactivate a row after disconnect.
  */
+export function findAnySessionByClientSessionId(
+  db: Database,
+  client_kind: ClientKind,
+  client_session_id: string,
+): SessionRow | null {
+  const row = db.query<SessionRow, [ClientKind, string]>(
+    `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
+            last_activity, last_seen_at, released_at
+     FROM sessions
+     WHERE client_kind = ? AND client_session_id = ?`,
+  ).get(client_kind, client_session_id)
+  return row ?? null
+}
+
 export function findAnySessionByCcSessionId(
   db: Database,
   cc_session_id: string,
 ): SessionRow | null {
-  const row = db.query<SessionRow, [string]>(
-    `SELECT id, alias, cc_session_id, created_at, last_activity, released_at
-     FROM sessions
-     WHERE cc_session_id = ?`,
-  ).get(cc_session_id)
-  return row ?? null
+  return findAnySessionByClientSessionId(db, 'claude_code', cc_session_id)
 }
 
 export function releaseSession(db: Database, id: string): void {
@@ -120,6 +214,7 @@ export interface InsertMessageInput {
   sender_id: string
   recipient_id: string
   broadcast_id: string | null
+  reply_to?: string | null
   content: string
 }
 
@@ -127,15 +222,25 @@ export function insertMessage(db: Database, input: InsertMessageInput): string {
   const id = randomUUID()
   const now = nowUtc()
   db.query(`
-    INSERT INTO messages (id, sender_id, recipient_id, broadcast_id, content, created_at, read_at)
-    VALUES (?, ?, ?, ?, ?, ?, NULL)
-  `).run(id, input.sender_id, input.recipient_id, input.broadcast_id, input.content, now)
+    INSERT INTO messages (
+      id, sender_id, recipient_id, broadcast_id, reply_to, content, created_at, read_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+  `).run(
+    id,
+    input.sender_id,
+    input.recipient_id,
+    input.broadcast_id,
+    input.reply_to ?? null,
+    input.content,
+    now,
+  )
   return id
 }
 
 export function fetchUnreadForRecipient(db: Database, recipient_id: string): MessageRow[] {
   return db.query<MessageRow, [string]>(`
-    SELECT id, sender_id, recipient_id, broadcast_id, content, created_at, read_at
+    SELECT id, sender_id, recipient_id, broadcast_id, reply_to, content, created_at, read_at
     FROM messages
     WHERE recipient_id = ? AND read_at IS NULL
     ORDER BY created_at ASC
@@ -170,8 +275,10 @@ export function insertBroadcast(db: Database, input: BroadcastInput): BroadcastD
 
   const now = nowUtc()
   const stmt = db.query(`
-    INSERT INTO messages (id, sender_id, recipient_id, broadcast_id, content, created_at, read_at)
-    VALUES (?, ?, ?, ?, ?, ?, NULL)
+    INSERT INTO messages (
+      id, sender_id, recipient_id, broadcast_id, reply_to, content, created_at, read_at
+    )
+    VALUES (?, ?, ?, ?, NULL, ?, ?, NULL)
   `)
   const insertTx = db.transaction((rows: typeof recipients) => {
     for (const r of rows) {
@@ -215,7 +322,10 @@ export function recallMessage(db: Database, input: RecallInput): number {
 
 export function listAllSessions(db: Database): SessionRow[] {
   return db.query<SessionRow, []>(
-    'SELECT id, alias, created_at, last_activity FROM sessions ORDER BY created_at ASC'
+    `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
+            last_activity, last_seen_at, released_at
+     FROM sessions
+     ORDER BY created_at ASC`,
   ).all()
 }
 

--- a/db.ts
+++ b/db.ts
@@ -49,6 +49,9 @@ function migrateSchema(db: Database): void {
     if (!sessionColumns.has('last_seen_at')) {
       db.exec('ALTER TABLE sessions ADD COLUMN last_seen_at TEXT')
     }
+    if (!sessionColumns.has('generation')) {
+      db.exec('ALTER TABLE sessions ADD COLUMN generation INTEGER NOT NULL DEFAULT 1')
+    }
     if (!sessionColumns.has('released_at')) {
       db.exec('ALTER TABLE sessions ADD COLUMN released_at TEXT')
     }
@@ -106,9 +109,9 @@ export function createClientSession(
   db.query(`
     INSERT INTO sessions (
       id, alias, client_kind, client_session_id, cwd,
-      created_at, last_activity, last_seen_at, released_at
+      created_at, last_activity, last_seen_at, generation, released_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+    VALUES (?, ?, ?, ?, ?, ?, ?, NULL, 1, NULL)
   `).run(
     id,
     opts.alias,
@@ -124,7 +127,7 @@ export function createClientSession(
 export function findSessionById(db: Database, id: string): SessionRow | null {
   const row = db.query<SessionRow, [string]>(
     `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
-            last_activity, last_seen_at, released_at
+            last_activity, last_seen_at, generation, released_at
      FROM sessions
      WHERE id = ?`,
   ).get(id)
@@ -134,7 +137,7 @@ export function findSessionById(db: Database, id: string): SessionRow | null {
 export function findSessionByAlias(db: Database, alias: string): SessionRow | null {
   const row = db.query<SessionRow, [string]>(
     `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
-            last_activity, last_seen_at, released_at
+            last_activity, last_seen_at, generation, released_at
      FROM sessions
      WHERE alias = ? AND released_at IS NULL`,
   ).get(alias)
@@ -148,7 +151,7 @@ export function findSessionByClientSessionId(
 ): SessionRow | null {
   const row = db.query<SessionRow, [ClientKind, string]>(
     `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
-            last_activity, last_seen_at, released_at
+            last_activity, last_seen_at, generation, released_at
      FROM sessions
      WHERE client_kind = ? AND client_session_id = ? AND released_at IS NULL`,
   ).get(client_kind, client_session_id)
@@ -173,9 +176,11 @@ export function findAnySessionByClientSessionId(
 ): SessionRow | null {
   const row = db.query<SessionRow, [ClientKind, string]>(
     `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
-            last_activity, last_seen_at, released_at
+            last_activity, last_seen_at, generation, released_at
      FROM sessions
-     WHERE client_kind = ? AND client_session_id = ?`,
+     WHERE client_kind = ? AND client_session_id = ?
+     ORDER BY (released_at IS NULL) DESC, generation DESC, created_at DESC
+     LIMIT 1`,
   ).get(client_kind, client_session_id)
   return row ?? null
 }
@@ -185,6 +190,101 @@ export function findAnySessionByCcSessionId(
   cc_session_id: string,
 ): SessionRow | null {
   return findAnySessionByClientSessionId(db, 'claude_code', cc_session_id)
+}
+
+export interface RegisterClientSessionInput {
+  alias: string | null
+  client_kind: ClientKind
+  client_session_id: string
+  cwd?: string | null
+}
+
+/**
+ * Register a durable client identity. Existing active or released rows are
+ * reused and receive a fresh generation so delayed lifecycle requests from an
+ * older client instance cannot affect the new one.
+ */
+export function registerClientSession(
+  db: Database,
+  input: RegisterClientSessionInput,
+): SessionRow {
+  return db.transaction(() => {
+    const existing = findAnySessionByClientSessionId(
+      db,
+      input.client_kind,
+      input.client_session_id,
+    )
+
+    if (!existing) {
+      if (input.alias !== null) {
+        const conflict = findSessionByAlias(db, input.alias)
+        if (conflict) {
+          throw new Error(`alias already taken: ${input.alias}`)
+        }
+      }
+      const id = createClientSession(db, input)
+      return findSessionById(db, id)!
+    }
+
+    const targetAlias = input.alias ?? existing.alias
+    if (targetAlias !== null) {
+      const conflict = findSessionByAlias(db, targetAlias)
+      if (conflict && conflict.id !== existing.id) {
+        throw new Error(`alias already taken: ${targetAlias}`)
+      }
+    }
+
+    const now = nowUtc()
+    db.query(`
+      UPDATE sessions
+      SET alias = ?,
+          cwd = CASE WHEN ? THEN ? ELSE cwd END,
+          last_activity = ?,
+          generation = generation + 1,
+          released_at = NULL
+      WHERE id = ?
+    `).run(
+      targetAlias,
+      input.cwd !== undefined ? 1 : 0,
+      input.cwd ?? null,
+      now,
+      existing.id,
+    )
+    return findSessionById(db, existing.id)!
+  })()
+}
+
+export type UnregisterClientSessionResult =
+  | 'released'
+  | 'already_released'
+  | 'not_found'
+  | 'generation_mismatch'
+
+export function unregisterClientSession(
+  db: Database,
+  input: {
+    client_kind: ClientKind
+    client_session_id: string
+    generation: number
+  },
+): UnregisterClientSessionResult {
+  return db.transaction(() => {
+    const existing = findAnySessionByClientSessionId(
+      db,
+      input.client_kind,
+      input.client_session_id,
+    )
+    if (!existing) return 'not_found'
+    if (existing.generation !== input.generation) return 'generation_mismatch'
+    if (existing.released_at !== null) return 'already_released'
+
+    const result = db.query(`
+      UPDATE sessions
+      SET alias = NULL, released_at = ?
+      WHERE id = ? AND generation = ? AND released_at IS NULL
+    `).run(nowUtc(), existing.id, input.generation)
+    return Number(result.changes) === 1 ? 'released' : 'generation_mismatch'
+  })()
 }
 
 export function releaseSession(db: Database, id: string): void {
@@ -323,7 +423,7 @@ export function recallMessage(db: Database, input: RecallInput): number {
 export function listAllSessions(db: Database): SessionRow[] {
   return db.query<SessionRow, []>(
     `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
-            last_activity, last_seen_at, released_at
+            last_activity, last_seen_at, generation, released_at
      FROM sessions
      ORDER BY created_at ASC`,
   ).all()

--- a/docs/plans/2026-07-24-bidirectional-peer-schema-migration.md
+++ b/docs/plans/2026-07-24-bidirectional-peer-schema-migration.md
@@ -1,0 +1,121 @@
+# Switchboard 雙邊 Peer Schema Migration 實作計畫
+
+> **給執行者：** 使用執行計畫（`execute`）skill 逐步完成此計畫。步驟使用 checkbox（`- [ ]`）格式追蹤進度。
+
+**目標：** 在不破壞既有 Claude Code 行為或資料的前提下，把 sessions 與 messages schema 一次 migration 成支援多種 peer client 的形式。
+
+**方法：** 以 schema introspection 判斷既有資料庫欄位，在單一 SQLite transaction 內 rename／add columns 並替換 active client identity unique index。DB helper 以 `client_kind`、`client_session_id` 為核心，保留 `cc_session_id` wrapper 供既有 MCP、poll 與 monitor 呼叫。
+
+**工具 / 技術：** Bun、TypeScript、`bun:sqlite`、SQLite transactional DDL、`bun:test`
+
+---
+
+### 任務 1：以 migration 測試鎖定資料與 schema 相容性
+
+**檔案：**
+- 修改：`tests/db.test.ts`
+
+- [x] **步驟 1：建立現行 Phase 2.5 schema 的檔案型 DB fixture**
+
+在 temporary directory 建立含 `cc_session_id`、active／released sessions、既有 message 與舊 unique index 的 DB，記錄 migration 前資料。
+
+- [x] **步驟 2：寫 schema 與資料保留 assertions**
+
+呼叫 `openDatabase()` 後驗證 `cc_session_id` 已 rename、`client_kind`／`cwd`／`last_seen_at`／`reply_to` 存在、既有 session/message 欄位值未變，且既有 session 的 `client_kind` 為 `claude_code`。
+
+- [x] **步驟 3：寫新 identity index assertions**
+
+驗證相同 kind 的 active duplicate identity 被拒絕、不同 kind 可使用相同 `client_session_id`、released identity 不阻擋重用。
+
+- [x] **步驟 4：跑 migration 專屬測試確認失敗**
+
+執行：`bun test tests/db.test.ts --test-name-pattern migration`
+
+預期：FAIL，原因是目標欄位或 index 尚未存在，且既有資料尚未以新 schema 呈現。
+
+### 任務 2：實作 transactional schema migration
+
+**檔案：**
+- 修改：`db.ts`
+- 修改：`schema.sql`
+
+- [x] **步驟 1：更新 fresh database schema**
+
+將 sessions identity 改為 `client_kind TEXT NOT NULL DEFAULT 'claude_code'` 與 `client_session_id`，新增 `cwd`、`last_seen_at`；messages 新增 nullable `reply_to`；identity unique index 改為 `(client_kind, client_session_id)` 的 active partial index。
+
+- [x] **步驟 2：在 openDatabase schema bootstrap 前執行 transaction migration**
+
+若 sessions 已存在，於同一 transaction 內 rename `cc_session_id`、補齊新欄位、移除舊 index 並建立新 index；若 messages 已存在則補 `reply_to`。既有 rows 透過 NOT NULL default 回填 `claude_code`，不 drop tables。
+
+- [x] **步驟 3：跑 migration 專屬測試確認通過**
+
+執行：`bun test tests/db.test.ts --test-name-pattern migration`
+
+預期：PASS，0 failures。
+
+### 任務 3：一般化 TypeScript types 與 DB helpers
+
+**檔案：**
+- 修改：`types.ts`
+- 修改：`db.ts`
+- 修改：`server.ts`
+- 修改：`tests/db.test.ts`
+
+- [x] **步驟 1：新增 canonical peer identity types 與 helper 測試**
+
+測試 `createClientSession` 可建立不同 kind、cwd 的 session；`findSessionByClientSessionId` 以 kind 分 namespace；message insert/fetch 保留 nullable `reply_to`。
+
+- [x] **步驟 2：跑新增 helper 測試確認失敗**
+
+執行：`bun test tests/db.test.ts --test-name-pattern "client session|reply_to"`
+
+預期：FAIL，原因是 canonical helper 或欄位尚未實作。
+
+- [x] **步驟 3：實作 canonical helpers 與 Claude Code wrappers**
+
+`SessionRow` 改用新欄位；新增 client-kind-aware create/find helpers。既有 `createSession({ cc_session_id })`、`findSessionByCcSessionId` 與 `findAnySessionByCcSessionId` 保留為固定 `claude_code` wrapper，MCP register 參數與 `/poll?cc_session_id=` 不改。
+
+- [x] **步驟 4：更新 server 內部 row 欄位存取**
+
+通知判定改讀 canonical `client_session_id`；不新增 POST `/register`、lease、broadcast scope 或 waker 行為。
+
+- [x] **步驟 5：跑 DB 與 TypeScript 驗證**
+
+執行：`bun test tests/db.test.ts`
+
+預期：PASS，0 failures。
+
+執行：`bunx tsc --noEmit`
+
+預期：exit 0。
+
+### 任務 4：完整驗證與聚焦 commit
+
+**檔案：**
+- 檢查：本計畫所列全部修改檔
+
+- [x] **步驟 1：逐項對照 design spec 與 scope**
+
+確認 schema、index、資料保留、wrapper、reply_to 均涵蓋，且 diff 不含 POST `/register`、lease、broadcast scope 或 waker。
+
+- [x] **步驟 2：跑專屬與完整測試**
+
+執行：`bun test tests/db.test.ts --test-name-pattern migration`
+
+預期：PASS，0 failures。
+
+執行：`bun test`
+
+預期：全部測試 PASS，0 failures。
+
+- [x] **步驟 3：檢查 diff 與 working tree**
+
+執行：`git diff --check`、`git diff --stat`、`git status --short`
+
+預期：無 whitespace error，只有本階段相關檔案。
+
+- [x] **步驟 4：建立一顆聚焦 commit**
+
+執行：`git add ...` 後 `git commit -m "feat(db): generalize sessions for peer clients"`
+
+預期：commit 成功；commit 後 `git status --short` 無輸出。不 push。

--- a/docs/plans/2026-07-24-http-peer-register.md
+++ b/docs/plans/2026-07-24-http-peer-register.md
@@ -1,0 +1,144 @@
+# Switchboard HTTP Peer Register 實作計畫
+
+> **給執行者：** 使用執行計畫（`execute`）skill 逐步完成此計畫。步驟使用 checkbox（`- [ ]`）格式追蹤進度。
+
+**目標：** 為不持有 MCP 連線的 peer 提供具 runtime validation、冪等 re-register 與 generation 防誤殺語意的 HTTP register／unregister API。
+
+**方法：** 沿用既有 `migrateSchema()` 模式新增 generation 欄位，並把 identity upsert 與 generation-guarded release 收斂為 DB helper。HTTP handler 僅負責解析、驗證、映射明確的 4xx 回應；既有 MCP register 改用相同 upsert helper，但維持原 response 與 transport lifecycle。
+
+**工具 / 技術：** Bun、TypeScript、`bun:sqlite`、Bun HTTP server、`bun:test`
+
+---
+
+### 任務 1：以測試鎖定 generation schema 與 DB 行為
+
+**檔案：**
+- 修改：`tests/db.test.ts`
+
+- [x] **步驟 1：擴充 migration 測試**
+
+在既有 Phase 2.5 DB fixture migration 後，驗證 `generation` 欄位存在且歷史 rows 均為 `1`。
+
+- [x] **步驟 2：新增 identity upsert 測試**
+
+驗證相同 `(client_kind, client_session_id)` 首次 register 為 generation 1；再次 register 沿用 session id、更新 alias／cwd、generation 變 2；released row 再 register 仍沿用 id 並遞增。
+
+- [x] **步驟 3：新增 generation-guarded release 測試**
+
+驗證舊 generation 無法 release re-register 後的 active row，目前 generation 可以 release，重送目前 generation 呈現 already released。
+
+- [x] **步驟 4：跑 DB 聚焦測試確認失敗**
+
+執行：`bun test tests/db.test.ts --test-name-pattern "migration|generation|upsert"`
+
+預期：FAIL，原因是 schema／types／helpers 尚未支援 generation。
+
+### 任務 2：以 integration tests 鎖定 HTTP contract
+
+**檔案：**
+- 修改：`tests/integration.test.ts`
+
+- [x] **步驟 1：新增 register 冪等與 reactivation 測試**
+
+呼叫 `POST /register`，驗證回傳 `{session_id, alias, generation}`；同 identity 重註冊與 unregister 後重註冊均沿用 session id、遞增 generation 並更新 alias。
+
+- [x] **步驟 2：新增 stale unregister 防誤殺測試**
+
+以舊 generation 呼叫 `POST /unregister`，預期 409 與明確 error；接著用目前 generation 應仍能成功釋放，證明舊請求未誤殺。
+
+- [x] **步驟 3：新增 runtime validation 與 alias conflict 測試**
+
+覆蓋 invalid JSON、非 object body、缺少／空白欄位、未知 `client_kind`、非正整數 generation，均回 400 與具欄位名稱的 error；不同 identity 佔用 active alias 時回 409 與 `alias already taken`。
+
+- [x] **步驟 4：跑 HTTP 聚焦測試確認失敗**
+
+執行：`bun test tests/integration.test.ts --test-name-pattern "HTTP register|HTTP unregister"`
+
+預期：FAIL，原因是 `/register`、`/unregister` 尚未存在。
+
+### 任務 3：實作 generation migration 與 canonical DB helpers
+
+**檔案：**
+- 修改：`schema.sql`
+- 修改：`types.ts`
+- 修改：`db.ts`
+
+- [x] **步驟 1：新增 generation schema 與 migration**
+
+fresh schema 加入 `generation INTEGER NOT NULL DEFAULT 1`；既有 sessions 缺欄位時以相同定義 `ALTER TABLE ... ADD COLUMN`，讓歷史資料回填 1。
+
+- [x] **步驟 2：讓 SessionRow 與所有 session SELECT 包含 generation**
+
+更新 shared type 與 DB row projections，避免 runtime row 與 TypeScript 定義分歧。
+
+- [x] **步驟 3：實作 transaction identity upsert**
+
+新增 helper：新 row generation 1；既有 active／released row沿用 id、更新 alias／可提供的 cwd、清除 released_at、更新 activity 並 `generation + 1`。alias collision 在 transaction 內明確拒絕。
+
+- [x] **步驟 4：實作 generation-guarded release**
+
+以 identity、generation 與 active 條件做 conditional UPDATE，並區分 released、not found、generation mismatch 結果。
+
+- [x] **步驟 5：跑 DB 聚焦測試**
+
+執行：`bun test tests/db.test.ts --test-name-pattern "migration|generation|upsert"`
+
+預期：PASS，0 failures。
+
+### 任務 4：實作 HTTP endpoints 並共用 MCP upsert 語意
+
+**檔案：**
+- 修改：`server.ts`
+
+- [x] **步驟 1：建立 JSON body 與欄位 validation helpers**
+
+拒絕 invalid JSON／非 object；alias、client session id、cwd 必須為非空字串；client kind 僅接受 `claude_code|codex|external`；generation 必須為正整數。
+
+- [x] **步驟 2：實作 `POST /register`**
+
+呼叫 canonical DB upsert，成功回 `{session_id, alias, generation}`；alias conflict 回 409；錯誤 method 回 405。
+
+- [x] **步驟 3：實作 `POST /unregister`**
+
+呼叫 guarded release；成功／already released 回 200；identity not found 回 404；generation mismatch 回 409；錯誤 method 回 405。
+
+- [x] **步驟 4：既有 MCP register 改用 canonical upsert**
+
+維持無 `cc_session_id` 每次新建、既有 response shape、registry 與 transport cleanup；有 identity 時讓每次 register 都符合 generation 遞增與 released reactivation 語意。
+
+- [x] **步驟 5：跑 integration 聚焦測試**
+
+執行：`bun test tests/integration.test.ts --test-name-pattern "HTTP register|HTTP unregister|register\\("`
+
+預期：PASS，0 failures。
+
+### 任務 5：完整驗證與聚焦 commit
+
+**檔案：**
+- 檢查：本計畫所列全部修改檔
+
+- [x] **步驟 1：跑 TypeScript 與完整測試**
+
+執行：`bunx tsc --noEmit`
+
+預期：exit 0。
+
+執行：`bun test`
+
+預期：全部測試 PASS，0 failures，既有 MCP／poll／monitor／external send 測試不回歸。
+
+- [x] **步驟 2：逐項對照階段 scope**
+
+確認只含 HTTP register/unregister、generation、validation 與必要共用 helper；不含 lease、poll 一般化、broadcast scope 或 waker。
+
+- [x] **步驟 3：檢查 diff 與 working tree**
+
+執行：`git diff --check`、`git diff --stat`、`git status --short`
+
+預期：無 whitespace error，只有本階段相關檔案。
+
+- [x] **步驟 4：建立一顆聚焦 commit**
+
+執行：`git add ...` 後 `git commit -m "feat(server): HTTP register for non-MCP peers"`
+
+預期：commit 成功；commit 後 `git status --short` 無輸出。不 push。

--- a/docs/superpowers/specs/2026-07-24-switchboard-bidirectional-peer-design.md
+++ b/docs/superpowers/specs/2026-07-24-switchboard-bidirectional-peer-design.md
@@ -1,9 +1,15 @@
 # Switchboard 雙邊 Peer 化設計（Codex 完整入網）
 
 - 日期：2026-07-24
-- 狀態：**設計定案，未實作**
+- 狀態：**實作完成，待 PR 整體終檢**（同日五階段交付）
 - 參與：阿童（決策）、阿宇（Claude Code）、小回（Codex）
 - 討論紀錄：codex thread `019f926a-2c4e-78d2-be12-147118a942ab`（`codex resume` 可回看完整往返）
+- 實作 commits：`87eced6`（schema migration）→ `15abe60`（HTTP register/unregister）→
+  `09a4d5e`＋`707d6b7`（lease、/poll 一般化、generation guard 全通路）→
+  `657acbd`（broadcast scope）；waker 在 codex-bridge repo `cad6583`
+- 後續非阻擋項目：新增由 `client_kind + client_session_id + generation` 驗證身分的
+  HTTP peer message-read endpoint，回傳與 MCP `read_messages` 相同欄位並維持一致的
+  read-at 語意。Codex waker 已預留 full-message adapter；本次 PR 不包含此 endpoint。
 
 ## 背景與目標
 

--- a/online.ts
+++ b/online.ts
@@ -1,0 +1,34 @@
+import type { ConnectionRegistry } from './connections'
+import type { SessionRow } from './types'
+import type { UnreadWaiterRegistry } from './waiters'
+
+const ONE_MINUTE_MS = 60_000
+
+// A poll may remain open for 250 seconds. Five minutes covers that full wait
+// and leaves roughly 50 seconds for a client to reconnect without flickering
+// offline.
+export const LEASE_TTL_MS = 5 * ONE_MINUTE_MS
+
+export function hasValidLease(
+  session: SessionRow,
+  nowMs = Date.now(),
+): boolean {
+  if (!session.last_seen_at) return false
+  const lastSeenMs = Date.parse(session.last_seen_at)
+  return Number.isFinite(lastSeenMs) && nowMs - lastSeenMs < LEASE_TTL_MS
+}
+
+export function isSessionOnline(
+  session: SessionRow,
+  registry: ConnectionRegistry,
+  waiters: UnreadWaiterRegistry,
+  nowMs = Date.now(),
+): boolean {
+  if (session.released_at !== null) return false
+  if (registry.isOnline(session.id)) return true
+  if (!session.client_session_id) return false
+  return (
+    waiters.isPolling(session.client_kind, session.client_session_id) ||
+    hasValidLease(session, nowMs)
+  )
+}

--- a/poller.ts
+++ b/poller.ts
@@ -169,7 +169,8 @@ export function loadConfigFromHookStdin(
       [string]
     >(
       `SELECT id, alias FROM sessions
-       WHERE cc_session_id = ?
+       WHERE client_kind = 'claude_code'
+         AND client_session_id = ?
          AND released_at IS NULL
          AND alias IS NOT NULL`,
     ).get(ccSessionId)

--- a/retention.ts
+++ b/retention.ts
@@ -3,8 +3,7 @@ import { deleteExpiredMessages, releaseStaleActiveSessions } from './db'
 import type { ConnectionRegistry } from './connections'
 
 const ONE_HOUR_MS = 60 * 60 * 1000
-const ONE_MINUTE_MS = 60 * 1000
-const STALE_SESSION_THRESHOLD_MS = 5 * ONE_MINUTE_MS
+const STALE_SESSION_THRESHOLD_MS = 24 * ONE_HOUR_MS
 
 export interface RetentionHandle {
   stop(): void
@@ -47,7 +46,7 @@ export function startRetentionLoop(
   messagesTick()
   sessionsTick()
   const messagesTimer = setInterval(messagesTick, ONE_HOUR_MS)
-  const sessionsTimer = setInterval(sessionsTick, ONE_MINUTE_MS)
+  const sessionsTimer = setInterval(sessionsTick, 2 * ONE_HOUR_MS)
   return {
     stop() {
       clearInterval(messagesTimer)

--- a/schema.sql
+++ b/schema.sql
@@ -1,25 +1,29 @@
 CREATE TABLE IF NOT EXISTS sessions (
-    id            TEXT PRIMARY KEY,
-    alias         TEXT,
-    cc_session_id TEXT,
-    created_at    TEXT NOT NULL,
-    last_activity TEXT NOT NULL,
-    released_at   TEXT
+    id                TEXT PRIMARY KEY,
+    alias             TEXT,
+    client_kind       TEXT NOT NULL DEFAULT 'claude_code',
+    client_session_id TEXT,
+    cwd               TEXT,
+    created_at        TEXT NOT NULL,
+    last_activity     TEXT NOT NULL,
+    last_seen_at      TEXT,
+    released_at       TEXT
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_alias_active
     ON sessions(alias)
     WHERE alias IS NOT NULL AND released_at IS NULL;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_cc_session_id_active
-    ON sessions(cc_session_id)
-    WHERE cc_session_id IS NOT NULL AND released_at IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_client_identity_active
+    ON sessions(client_kind, client_session_id)
+    WHERE client_session_id IS NOT NULL AND released_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS messages (
     id            TEXT PRIMARY KEY,
     sender_id     TEXT NOT NULL,
     recipient_id  TEXT NOT NULL,
     broadcast_id  TEXT,
+    reply_to      TEXT,
     content       TEXT NOT NULL,
     created_at    TEXT NOT NULL,
     read_at       TEXT,

--- a/schema.sql
+++ b/schema.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     created_at        TEXT NOT NULL,
     last_activity     TEXT NOT NULL,
     last_seen_at      TEXT,
+    generation        INTEGER NOT NULL DEFAULT 1,
     released_at       TEXT
 );
 

--- a/scratch/check-orphan-ccs.ts
+++ b/scratch/check-orphan-ccs.ts
@@ -7,6 +7,10 @@ const ids = [
   '90d5a83d-27f3-4a38-b51f-81dbc7ef63a4',
 ]
 for (const cc of ids) {
-  const rows = db.query('SELECT id, alias, cc_session_id, last_activity, released_at FROM sessions WHERE cc_session_id = ?').all(cc)
+  const rows = db.query(`
+    SELECT id, alias, client_session_id, last_activity, released_at
+    FROM sessions
+    WHERE client_kind = 'claude_code' AND client_session_id = ?
+  `).all(cc)
   console.log(cc, JSON.stringify(rows))
 }

--- a/server.ts
+++ b/server.ts
@@ -595,9 +595,16 @@ export async function startServer(opts: {
             content: [{ type: 'text', text: JSON.stringify({ status: 'already_offline' }) }],
           }
         }
-        const releasedAlias = findSessionById(db, currentSwitchboardId)?.alias ?? null
-        releaseSession(db, currentSwitchboardId)
-        registry.unregister(currentSwitchboardId)
+        // Generation guard: if a newer transport re-registered this identity,
+        // a stale transport's explicit unregister must not release the new
+        // generation's row — mirror the transport.onclose cleanup semantics.
+        if (currentPushCallback) {
+          registry.unregister(currentSwitchboardId, currentPushCallback)
+        }
+        const priorAlias = findSessionById(db, currentSwitchboardId)?.alias ?? null
+        const released =
+          currentGeneration !== null &&
+          releaseSessionIfGeneration(db, currentSwitchboardId, currentGeneration)
         currentSwitchboardId = null
         currentGeneration = null
         currentPushCallback = null
@@ -605,7 +612,11 @@ export async function startServer(opts: {
           content: [
             {
               type: 'text',
-              text: JSON.stringify({ status: 'released', released_alias: releasedAlias }),
+              text: JSON.stringify(
+                released
+                  ? { status: 'released', released_alias: priorAlias }
+                  : { status: 'stale_ignored', released_alias: null },
+              ),
             },
           ],
         }

--- a/server.ts
+++ b/server.ts
@@ -18,13 +18,13 @@ import {
   isInitializeRequest,
 } from '@modelcontextprotocol/sdk/types.js'
 import type { Database } from 'bun:sqlite'
-import { openDatabase, createSession, findSessionById, findSessionByAlias, findSessionByCcSessionId, findSessionByClientSessionId, findAnySessionByClientSessionId, registerClientSession, unregisterClientSession, updateLastActivity, updateLastSeen, releaseSession, releaseSessionIfGeneration, insertMessage, insertBroadcast, fetchUnreadForRecipient, markMessagesRead, listAllSessions, recallMessage, countUnreadBySessionId } from './db'
+import { openDatabase, createSession, findSessionById, findSessionByAlias, findSessionByCcSessionId, findSessionByClientSessionId, findAnySessionByClientSessionId, registerClientSession, unregisterClientSession, updateLastActivity, updateLastSeen, releaseSessionIfGeneration, insertMessage, insertBroadcast, fetchUnreadForRecipient, markMessagesRead, listAllSessions, recallMessage, countUnreadBySessionId } from './db'
 import { ConnectionRegistry, type PushCallback } from './connections'
 import { setAliasWithCollisionCheck, resolveTarget } from './aliases'
 import { toTaipeiISOString } from './time'
 import { startRetentionLoop } from './retention'
 import { UnreadWaiterRegistry } from './waiters'
-import type { ClientKind } from './types'
+import type { BroadcastScope, ClientKind, SessionRow } from './types'
 import { isSessionOnline } from './online'
 
 export interface ServerHandle {
@@ -37,8 +37,36 @@ interface SessionEntry {
 }
 
 const CLIENT_KINDS: readonly ClientKind[] = ['claude_code', 'codex', 'external']
+const BROADCAST_SCOPES: readonly BroadcastScope[] = ['all', 'same_kind', 'same_cwd']
 
 class RequestValidationError extends Error {}
+
+function requireBroadcastScope(value: unknown): BroadcastScope {
+  if (value === undefined) return 'all'
+  if (
+    typeof value !== 'string' ||
+    !BROADCAST_SCOPES.includes(value as BroadcastScope)
+  ) {
+    throw new Error(`scope must be one of: ${BROADCAST_SCOPES.join(', ')}`)
+  }
+  return value as BroadcastScope
+}
+
+function matchesBroadcastScope(
+  sender: SessionRow,
+  recipient: SessionRow,
+  scope: BroadcastScope,
+): boolean {
+  if (scope === 'all') return true
+  if (scope === 'same_kind') {
+    return recipient.client_kind === sender.client_kind
+  }
+  return (
+    sender.cwd !== null &&
+    recipient.cwd !== null &&
+    recipient.cwd === sender.cwd
+  )
+}
 
 function requireJsonObject(body: unknown): Record<string, unknown> {
   if (typeof body !== 'object' || body === null || Array.isArray(body)) {
@@ -338,10 +366,20 @@ export async function startServer(opts: {
         },
         {
           name: 'broadcast',
-          description: 'Send to all currently registered sessions (except self).',
+          description: 'Broadcast to active sessions selected by scope (except self).',
           inputSchema: {
             type: 'object' as const,
-            properties: { message: { type: 'string' } },
+            properties: {
+              message: { type: 'string' },
+              scope: {
+                type: 'string',
+                enum: BROADCAST_SCOPES,
+                default: 'all',
+                description:
+                  'all: every active session; same_kind: sender client_kind; ' +
+                  'same_cwd: equal non-NULL cwd.',
+              },
+            },
             required: ['message'],
           },
         },
@@ -514,10 +552,23 @@ export async function startServer(opts: {
 
       if (name === 'broadcast') {
         if (!currentSwitchboardId) throw new Error('session not registered; call register() first')
-        const message = (args as Record<string, unknown>)?.message as string
+        const argsObj = (args as Record<string, unknown>) ?? {}
+        const message = argsObj.message as string
+        const scope = requireBroadcastScope(argsObj.scope)
         const sender = findSessionById(db, currentSwitchboardId)
+        if (!sender) throw new Error('registered sender session not found')
+        const recipients = listAllSessions(db).filter((recipient) => (
+          recipient.id !== currentSwitchboardId &&
+          recipient.released_at === null &&
+          matchesBroadcastScope(sender, recipient, scope) &&
+          (
+            recipient.client_kind !== 'codex' ||
+            isSessionOnline(recipient, registry, waiters)
+          )
+        ))
         const { broadcast_id, recipient_count, recipient_ids } = insertBroadcast(db, {
           sender_id: currentSwitchboardId,
+          recipient_ids: recipients.map((recipient) => recipient.id),
           content: message,
         })
         // Wake every long-poll waiter that just got a new message row.

--- a/server.ts
+++ b/server.ts
@@ -18,13 +18,14 @@ import {
   isInitializeRequest,
 } from '@modelcontextprotocol/sdk/types.js'
 import type { Database } from 'bun:sqlite'
-import { openDatabase, createSession, findSessionById, findSessionByAlias, findSessionByCcSessionId, findAnySessionByClientSessionId, registerClientSession, unregisterClientSession, updateLastActivity, releaseSession, insertMessage, insertBroadcast, fetchUnreadForRecipient, markMessagesRead, listAllSessions, recallMessage, countUnreadBySessionId } from './db'
-import { ConnectionRegistry } from './connections'
+import { openDatabase, createSession, findSessionById, findSessionByAlias, findSessionByCcSessionId, findSessionByClientSessionId, findAnySessionByClientSessionId, registerClientSession, unregisterClientSession, updateLastActivity, updateLastSeen, releaseSession, releaseSessionIfGeneration, insertMessage, insertBroadcast, fetchUnreadForRecipient, markMessagesRead, listAllSessions, recallMessage, countUnreadBySessionId } from './db'
+import { ConnectionRegistry, type PushCallback } from './connections'
 import { setAliasWithCollisionCheck, resolveTarget } from './aliases'
 import { toTaipeiISOString } from './time'
 import { startRetentionLoop } from './retention'
 import { UnreadWaiterRegistry } from './waiters'
 import type { ClientKind } from './types'
+import { isSessionOnline } from './online'
 
 export interface ServerHandle {
   stop(): Promise<void>
@@ -87,20 +88,6 @@ export async function startServer(opts: {
   const registry = new ConnectionRegistry()
   const retention = startRetentionLoop(db, registry)
   const waiters = new UnreadWaiterRegistry()
-
-  // "recipient can be auto-woken" — true iff a curl shim is currently
-  // long-polling /poll for this cc_session_id. A shim in /poll guarantees
-  // the daemon will push the message the moment insertMessage completes.
-  //
-  // Previously this also fell back to poller.ts's state-file check
-  // (legacy bun-based poller). That was removed because: (1) the shim
-  // doesn't write state files, so on a stale file the pid may have been
-  // reused by an unrelated process, yielding false positives; (2) the
-  // in-memory polling set is the truthful signal.
-  const canAutoWake = (ccSessionId: string | null | undefined): boolean => {
-    if (!ccSessionId) return false
-    return waiters.isPolling(ccSessionId)
-  }
 
   const getOrCreateExternalSender = (alias: string): string => {
     const existing = findSessionByAlias(db, alias)
@@ -237,7 +224,8 @@ export async function startServer(opts: {
       const recipient = findSessionById(db, targetId)
       return Response.json({
         message_id,
-        delivered_notification: pushed && canAutoWake(recipient?.client_session_id),
+        delivered_notification:
+          pushed || (recipient ? isSessionOnline(recipient, registry, waiters) : false),
       })
     } catch (e) {
       return Response.json({ error: e instanceof Error ? e.message : String(e) }, { status: 400 })
@@ -261,6 +249,8 @@ export async function startServer(opts: {
   function createMcpSession(): WebStandardStreamableHTTPServerTransport {
     // Current switchboard session ID for this MCP session (set by register tool)
     let currentSwitchboardId: string | null = null
+    let currentGeneration: number | null = null
+    let currentPushCallback: PushCallback | null = null
 
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: () => crypto.randomUUID(),
@@ -278,8 +268,12 @@ export async function startServer(opts: {
         mcpSessionToSwitchboard.delete(mcpSessionId)
       }
       if (currentSwitchboardId) {
-        releaseSession(db, currentSwitchboardId)
-        registry.unregister(currentSwitchboardId)
+        if (currentPushCallback) {
+          registry.unregister(currentSwitchboardId, currentPushCallback)
+        }
+        if (currentGeneration !== null) {
+          releaseSessionIfGeneration(db, currentSwitchboardId, currentGeneration)
+        }
       }
     }
 
@@ -392,16 +386,19 @@ export async function startServer(opts: {
         const cc_session_id = (argsObj.cc_session_id as string | undefined) ?? null
 
         let sessionId: string
+        let generation: number
 
         if (cc_session_id) {
           // Durable Claude Code identities share the same generation-aware
           // upsert semantics as HTTP peers. The MCP response shape remains
           // unchanged for backward compatibility.
-          sessionId = registerClientSession(db, {
+          const registered = registerClientSession(db, {
             alias: role,
             client_kind: 'claude_code',
             client_session_id: cc_session_id,
-          }).id
+          })
+          sessionId = registered.id
+          generation = registered.generation
         } else {
           // Phase 1 fallback path: no cc_session_id means every call is a fresh session
           if (role !== null) {
@@ -411,14 +408,16 @@ export async function startServer(opts: {
             }
           }
           sessionId = createSession(db, { alias: role, cc_session_id: null })
+          generation = findSessionById(db, sessionId)!.generation
         }
 
         currentSwitchboardId = sessionId
+        currentGeneration = generation
         if (transport.sessionId) {
           mcpSessionToSwitchboard.set(transport.sessionId, sessionId)
         }
 
-        registry.register(sessionId, (payload) => {
+        const pushCallback: PushCallback = (payload) => {
           mcpServer
             .notification({
               method: 'notifications/switchboard/new_message',
@@ -430,9 +429,11 @@ export async function startServer(opts: {
               // Drop the leaked registry entry so list_sessions stops
               // reporting this session as online; retention will release
               // the DB row on its next tick.
-              registry.unregister(sessionId)
+              registry.unregister(sessionId, pushCallback)
             })
-        })
+        }
+        currentPushCallback = pushCallback
+        registry.register(sessionId, pushCallback)
 
         const finalAlias = findSessionById(db, sessionId)?.alias ?? null
         const anonymous = finalAlias === null
@@ -498,18 +499,14 @@ export async function startServer(opts: {
         // returns immediately with SWITCHBOARD INBOX. Safe to call even if
         // no waiter exists.
         waiters.notify(targetId)
-        // delivered_notification promises "the recipient will notice this
-        // without user intervention" — that requires a live transport
-        // (pushed) and a live auto-wake path (bun poller state file OR an
-        // active curl long-poll). Anonymous / Phase 1 recipients with no
-        // cc_session_id always get false — the honest answer.
         const recipient = findSessionById(db, targetId)
         return {
           content: [{
             type: 'text',
             text: JSON.stringify({
               message_id,
-              delivered_notification: pushed && canAutoWake(recipient?.client_session_id),
+              delivered_notification:
+                pushed || (recipient ? isSessionOnline(recipient, registry, waiters) : false),
             }),
           }],
         }
@@ -525,16 +522,20 @@ export async function startServer(opts: {
         })
         // Wake every long-poll waiter that just got a new message row.
         waiters.notifyMany(recipient_ids)
-        const onlineIds = registry.listOnline().filter(id => id !== currentSwitchboardId)
         let notified_count = 0
-        for (const id of onlineIds) {
+        for (const id of recipient_ids) {
           const pushed = registry.pushNotification(id, {
             sender_alias: sender?.alias ?? null,
             sender_id: currentSwitchboardId,
             is_broadcast: true,
           })
           const recipient = findSessionById(db, id)
-          if (pushed && canAutoWake(recipient?.client_session_id)) notified_count++
+          if (
+            pushed ||
+            (recipient ? isSessionOnline(recipient, registry, waiters) : false)
+          ) {
+            notified_count++
+          }
         }
         return {
           content: [{
@@ -570,7 +571,7 @@ export async function startServer(opts: {
         const result = all.map(s => ({
           session_id: s.id,
           alias: s.alias,
-          online: registry.isOnline(s.id),
+          online: isSessionOnline(s, registry, waiters),
           created_at: toTaipeiISOString(s.created_at),
           last_activity: toTaipeiISOString(s.last_activity),
         }))
@@ -598,6 +599,8 @@ export async function startServer(opts: {
         releaseSession(db, currentSwitchboardId)
         registry.unregister(currentSwitchboardId)
         currentSwitchboardId = null
+        currentGeneration = null
+        currentPushCallback = null
         return {
           content: [
             {
@@ -620,7 +623,7 @@ export async function startServer(opts: {
   }
 
   /**
-   * GET /poll?cc_session_id=X&timeout_s=N
+   * GET /poll?client_kind=K&client_session_id=X&timeout_s=N
    *
    * Long-poll endpoint for Stop-hook shim scripts. Replaces bun poller.ts —
    * the shim calls this and blocks on the daemon instead of running its own
@@ -638,19 +641,48 @@ export async function startServer(opts: {
       return new Response('Method Not Allowed', { status: 405 })
     }
     const ccSessionId = url.searchParams.get('cc_session_id')
-    if (!ccSessionId) {
-      return new Response('Missing cc_session_id', { status: 400 })
+    const canonicalSessionId = url.searchParams.get('client_session_id')
+    const canonicalKind = url.searchParams.get('client_kind')
+    if (ccSessionId && (canonicalSessionId || canonicalKind)) {
+      return new Response(
+        'Use either cc_session_id or client_kind + client_session_id',
+        { status: 400 },
+      )
+    }
+
+    let clientKind: ClientKind
+    let clientSessionId: string
+    if (ccSessionId) {
+      clientKind = 'claude_code'
+      clientSessionId = ccSessionId
+    } else {
+      if (!canonicalSessionId) {
+        return new Response('Missing client_session_id', { status: 400 })
+      }
+      if (!canonicalKind) {
+        return new Response('Missing client_kind', { status: 400 })
+      }
+      if (!CLIENT_KINDS.includes(canonicalKind as ClientKind)) {
+        return new Response(
+          `Invalid client_kind; expected one of: ${CLIENT_KINDS.join(', ')}`,
+          { status: 400 },
+        )
+      }
+      clientKind = canonicalKind as ClientKind
+      clientSessionId = canonicalSessionId
     }
     const timeoutRaw = url.searchParams.get('timeout_s') ?? '240'
     const parsed = parseInt(timeoutRaw, 10)
     const timeoutS = Math.min(Math.max(Number.isFinite(parsed) ? parsed : 240, 1), 250)
 
-    const session = findSessionByCcSessionId(db, ccSessionId)
+    const session = findSessionByClientSessionId(db, clientKind, clientSessionId)
     if (!session || !session.alias) {
       return Response.json({ status: 'no-session' })
     }
 
-    // A live curl long-poll counts as activity for retention purposes.
+    // Every valid poll renews the client's lease, including immediate unread
+    // responses that never enter the waiter registry.
+    updateLastSeen(db, session.id)
     updateLastActivity(db, session.id)
 
     const initial = countUnreadBySessionId(db, session.id)
@@ -663,7 +695,13 @@ export async function startServer(opts: {
       })
     }
 
-    await waiters.wait(session.id, ccSessionId, timeoutS * 1000, req.signal)
+    await waiters.wait(
+      session.id,
+      clientKind,
+      clientSessionId,
+      timeoutS * 1000,
+      req.signal,
+    )
     // Re-check: the waiter may have resolved because of a new message, a
     // timeout, or a client abort. Only the first case yields status=unread.
     const final = countUnreadBySessionId(db, session.id)
@@ -699,9 +737,8 @@ export async function startServer(opts: {
    *
    * Unlike /poll (one-shot long-poll that the shim loops), /monitor is
    * persistent — one HTTP connection for the lifetime of the session. The
-   * side effect of calling waiters.wait() here is that `canAutoWake` sees
-   * this cc_session_id as polling, so sender-side `delivered_notification`
-   * stays honest.
+   * side effect of calling waiters.wait() here is that the shared online
+   * predicate sees this Claude Code identity as polling.
    */
   async function handleMonitor(req: Request, url: URL): Promise<Response> {
     if (req.method !== 'GET') {
@@ -763,7 +800,13 @@ export async function startServer(opts: {
         const HEARTBEAT_LINE_EVERY = 30
         let silentTicks = 0
         while (!req.signal.aborted) {
-          await waiters.wait(sessionId, ccSessionId, HEARTBEAT_MS, req.signal)
+          await waiters.wait(
+            sessionId,
+            'claude_code',
+            ccSessionId,
+            HEARTBEAT_MS,
+            req.signal,
+          )
           if (req.signal.aborted) break
           const count = countUnreadBySessionId(db, sessionId)
           let ok: boolean

--- a/server.ts
+++ b/server.ts
@@ -106,7 +106,7 @@ export async function startServer(opts: {
       const recipient = findSessionById(db, targetId)
       return Response.json({
         message_id,
-        delivered_notification: pushed && canAutoWake(recipient?.cc_session_id),
+        delivered_notification: pushed && canAutoWake(recipient?.client_session_id),
       })
     } catch (e) {
       return Response.json({ error: e instanceof Error ? e.message : String(e) }, { status: 400 })
@@ -406,7 +406,7 @@ export async function startServer(opts: {
             type: 'text',
             text: JSON.stringify({
               message_id,
-              delivered_notification: pushed && canAutoWake(recipient?.cc_session_id),
+              delivered_notification: pushed && canAutoWake(recipient?.client_session_id),
             }),
           }],
         }
@@ -431,7 +431,7 @@ export async function startServer(opts: {
             is_broadcast: true,
           })
           const recipient = findSessionById(db, id)
-          if (pushed && canAutoWake(recipient?.cc_session_id)) notified_count++
+          if (pushed && canAutoWake(recipient?.client_session_id)) notified_count++
         }
         return {
           content: [{
@@ -451,6 +451,7 @@ export async function startServer(opts: {
             id: m.id,
             sender_id: m.sender_id,
             sender_alias: senderRow?.alias ?? null,
+            reply_to: m.reply_to,
             content: m.content,
             created_at: toTaipeiISOString(m.created_at),
             is_broadcast: m.broadcast_id !== null,

--- a/server.ts
+++ b/server.ts
@@ -18,12 +18,13 @@ import {
   isInitializeRequest,
 } from '@modelcontextprotocol/sdk/types.js'
 import type { Database } from 'bun:sqlite'
-import { openDatabase, createSession, findSessionById, findSessionByAlias, findSessionByCcSessionId, findAnySessionByCcSessionId, updateLastActivity, releaseSession, reactivateSession, insertMessage, insertBroadcast, fetchUnreadForRecipient, markMessagesRead, listAllSessions, recallMessage, countUnreadBySessionId } from './db'
+import { openDatabase, createSession, findSessionById, findSessionByAlias, findSessionByCcSessionId, findAnySessionByClientSessionId, registerClientSession, unregisterClientSession, updateLastActivity, releaseSession, insertMessage, insertBroadcast, fetchUnreadForRecipient, markMessagesRead, listAllSessions, recallMessage, countUnreadBySessionId } from './db'
 import { ConnectionRegistry } from './connections'
 import { setAliasWithCollisionCheck, resolveTarget } from './aliases'
 import { toTaipeiISOString } from './time'
 import { startRetentionLoop } from './retention'
 import { UnreadWaiterRegistry } from './waiters'
+import type { ClientKind } from './types'
 
 export interface ServerHandle {
   stop(): Promise<void>
@@ -32,6 +33,50 @@ export interface ServerHandle {
 interface SessionEntry {
   transport: WebStandardStreamableHTTPServerTransport
   mcpServer: Server
+}
+
+const CLIENT_KINDS: readonly ClientKind[] = ['claude_code', 'codex', 'external']
+
+class RequestValidationError extends Error {}
+
+function requireJsonObject(body: unknown): Record<string, unknown> {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    throw new RequestValidationError('request body must be a JSON object')
+  }
+  return body as Record<string, unknown>
+}
+
+function requireNonEmptyString(
+  body: Record<string, unknown>,
+  field: string,
+): string {
+  const value = body[field]
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new RequestValidationError(
+      `${field} is required and must be a non-empty string`,
+    )
+  }
+  return value.trim()
+}
+
+function requireClientKind(body: Record<string, unknown>): ClientKind {
+  const value = body.client_kind
+  if (typeof value !== 'string' || !CLIENT_KINDS.includes(value as ClientKind)) {
+    throw new RequestValidationError(
+      `client_kind must be one of: ${CLIENT_KINDS.join(', ')}`,
+    )
+  }
+  return value as ClientKind
+}
+
+function requireGeneration(body: Record<string, unknown>): number {
+  const value = body.generation
+  if (!Number.isSafeInteger(value) || (value as number) < 1) {
+    throw new RequestValidationError(
+      'generation is required and must be a positive integer',
+    )
+  }
+  return value as number
 }
 
 export async function startServer(opts: {
@@ -64,6 +109,92 @@ export async function startServer(opts: {
       return existing.id
     }
     return createSession(db, { alias, cc_session_id: null })
+  }
+
+  async function parseJsonBody(req: Request): Promise<Record<string, unknown>> {
+    let parsed: unknown
+    try {
+      parsed = await req.json()
+    } catch {
+      throw new RequestValidationError('invalid JSON body')
+    }
+    return requireJsonObject(parsed)
+  }
+
+  async function handleRegister(req: Request): Promise<Response> {
+    if (req.method !== 'POST') {
+      return new Response('Method Not Allowed', { status: 405 })
+    }
+
+    try {
+      const body = await parseJsonBody(req)
+      const alias = requireNonEmptyString(body, 'alias')
+      const client_kind = requireClientKind(body)
+      const client_session_id = requireNonEmptyString(body, 'client_session_id')
+      const cwd = requireNonEmptyString(body, 'cwd')
+      const session = registerClientSession(db, {
+        alias,
+        client_kind,
+        client_session_id,
+        cwd,
+      })
+      return Response.json({
+        session_id: session.id,
+        alias: session.alias,
+        generation: session.generation,
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (error instanceof RequestValidationError) {
+        return Response.json({ error: message }, { status: 400 })
+      }
+      if (message.startsWith('alias already taken:')) {
+        return Response.json({ error: message }, { status: 409 })
+      }
+      return Response.json({ error: 'internal server error' }, { status: 500 })
+    }
+  }
+
+  async function handleUnregister(req: Request): Promise<Response> {
+    if (req.method !== 'POST') {
+      return new Response('Method Not Allowed', { status: 405 })
+    }
+
+    try {
+      const body = await parseJsonBody(req)
+      const client_kind = requireClientKind(body)
+      const client_session_id = requireNonEmptyString(body, 'client_session_id')
+      const generation = requireGeneration(body)
+      const result = unregisterClientSession(db, {
+        client_kind,
+        client_session_id,
+        generation,
+      })
+
+      if (result === 'not_found') {
+        return Response.json({ error: 'session not found' }, { status: 404 })
+      }
+      if (result === 'generation_mismatch') {
+        const current = findAnySessionByClientSessionId(
+          db,
+          client_kind,
+          client_session_id,
+        )
+        return Response.json(
+          {
+            error: `generation mismatch: current generation is ${current?.generation ?? 'unknown'}`,
+          },
+          { status: 409 },
+        )
+      }
+      return Response.json({ status: result })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (error instanceof RequestValidationError) {
+        return Response.json({ error: message }, { status: 400 })
+      }
+      return Response.json({ error: 'internal server error' }, { status: 500 })
+    }
   }
 
   async function handleExternalSend(req: Request): Promise<Response> {
@@ -263,39 +394,14 @@ export async function startServer(opts: {
         let sessionId: string
 
         if (cc_session_id) {
-          // Phase 2.5 path: idempotent by cc_session_id.
-          // Use findAnySessionByCcSessionId to also find released rows so a
-          // reconnecting session can reactivate its original row.
-          const existing = findAnySessionByCcSessionId(db, cc_session_id)
-          if (existing) {
-            sessionId = existing.id
-            const isReleased = existing.released_at != null
-            if (isReleased) {
-              // Row was released on disconnect — reactivate it with the requested alias.
-              // Check for alias collision against other currently-active rows.
-              const targetAlias = role ?? existing.alias
-              if (targetAlias !== null) {
-                const conflict = findSessionByAlias(db, targetAlias)
-                if (conflict && conflict.id !== sessionId) {
-                  throw new Error(`alias already taken: ${targetAlias}`)
-                }
-              }
-              reactivateSession(db, sessionId, targetAlias)
-            } else if (role !== null && role !== existing.alias) {
-              // Active row — treat as a rename; throws AliasCollisionError if taken
-              setAliasWithCollisionCheck(db, sessionId, role)
-            }
-            updateLastActivity(db, sessionId)
-          } else {
-            // New session: validate role collision before insert
-            if (role !== null) {
-              const conflict = findSessionByAlias(db, role)
-              if (conflict) {
-                throw new Error(`alias already taken: ${role}`)
-              }
-            }
-            sessionId = createSession(db, { alias: role, cc_session_id })
-          }
+          // Durable Claude Code identities share the same generation-aware
+          // upsert semantics as HTTP peers. The MCP response shape remains
+          // unchanged for backward compatibility.
+          sessionId = registerClientSession(db, {
+            alias: role,
+            client_kind: 'claude_code',
+            client_session_id: cc_session_id,
+          }).id
         } else {
           // Phase 1 fallback path: no cc_session_id means every call is a fresh session
           if (role !== null) {
@@ -328,10 +434,7 @@ export async function startServer(opts: {
             })
         })
 
-        const finalAlias =
-          cc_session_id && role === null
-            ? findSessionById(db, sessionId)?.alias ?? null
-            : role
+        const finalAlias = findSessionById(db, sessionId)?.alias ?? null
         const anonymous = finalAlias === null
         const responseBody: Record<string, unknown> = {
           session_id: sessionId,
@@ -719,6 +822,14 @@ export async function startServer(opts: {
 
       if (url.pathname === '/external/send') {
         return handleExternalSend(req)
+      }
+
+      if (url.pathname === '/register') {
+        return handleRegister(req)
+      }
+
+      if (url.pathname === '/unregister') {
+        return handleUnregister(req)
       }
 
       if (url.pathname !== '/mcp') {

--- a/tests/connections.test.ts
+++ b/tests/connections.test.ts
@@ -23,6 +23,17 @@ test('unregister removes session', () => {
   expect(registry.isOnline('uuid-1')).toBe(false)
 })
 
+test('unregister with an older callback preserves the replacement connection', () => {
+  const older = () => {}
+  const current = () => {}
+  registry.register('uuid-1', older)
+  registry.register('uuid-1', current)
+
+  registry.unregister('uuid-1', older)
+
+  expect(registry.isOnline('uuid-1')).toBe(true)
+})
+
 test('pushNotification invokes callback for online target', () => {
   const pushed: any[] = []
   registry.register('uuid-1', (payload) => { pushed.push(payload) })
@@ -40,6 +51,7 @@ test('pushNotification returns false when callback throws (connection broken)', 
   registry.register('uuid-1', () => { throw new Error('broken') })
   const ok = registry.pushNotification('uuid-1', { sender_alias: 'alice' })
   expect(ok).toBe(false)
+  expect(registry.isOnline('uuid-1')).toBe(false)
 })
 
 test('listOnline returns all registered session_ids', () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -3,7 +3,7 @@ import { unlinkSync, existsSync, mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Database } from 'bun:sqlite'
-import { openDatabase, createClientSession, createSession, findSessionById, findSessionByAlias, findSessionByClientSessionId, findSessionByCcSessionId, registerClientSession, unregisterClientSession, releaseSession, updateLastActivity, insertMessage, fetchUnreadForRecipient, markMessagesRead, insertBroadcast, recallMessage, listAllSessions, deleteExpiredMessages, releaseStaleActiveSessions } from '../db'
+import { openDatabase, createClientSession, createSession, findSessionById, findSessionByAlias, findSessionByClientSessionId, findSessionByCcSessionId, registerClientSession, unregisterClientSession, releaseSession, updateLastActivity, updateLastSeen, insertMessage, fetchUnreadForRecipient, markMessagesRead, insertBroadcast, recallMessage, listAllSessions, deleteExpiredMessages, releaseStaleActiveSessions } from '../db'
 
 const TEST_DB = ':memory:'
 let db: Database
@@ -54,6 +54,23 @@ test('updateLastActivity changes last_activity but not created_at', async () => 
   const after = findSessionById(db, id)!
   expect(after.created_at).toBe(before.created_at)
   expect(after.last_activity > before.last_activity).toBe(true)
+})
+
+test('updateLastSeen renews the session lease without changing last_activity', async () => {
+  const id = createClientSession(db, {
+    alias: 'lease-client',
+    client_kind: 'codex',
+    client_session_id: 'lease-id',
+  })
+  const before = findSessionById(db, id)!
+  await Bun.sleep(10)
+
+  updateLastSeen(db, id)
+
+  const after = findSessionById(db, id)!
+  expect(after.last_seen_at).not.toBeNull()
+  expect(Date.parse(after.last_seen_at!)).toBeGreaterThan(Date.parse(before.created_at))
+  expect(after.last_activity).toBe(before.last_activity)
 })
 
 test('insertMessage + fetchUnread round trip (1-to-1)', () => {
@@ -619,4 +636,18 @@ test('releaseStaleActiveSessions frees alias for re-use', () => {
   const second = createSession(db, { alias: 'shared-name' })
   expect(second).not.toBe(first)
   expect(findSessionByAlias(db, 'shared-name')?.id).toBe(second)
+})
+
+test('releaseStaleActiveSessions uses last_seen_at when a lease has been renewed', () => {
+  const id = createClientSession(db, {
+    alias: 'leased',
+    client_kind: 'codex',
+    client_session_id: 'leased-id',
+  })
+  backdateLastActivity(db, id, 48 * 60 * 60_000)
+  db.query('UPDATE sessions SET last_seen_at = ? WHERE id = ?')
+    .run(new Date().toISOString(), id)
+
+  expect(releaseStaleActiveSessions(db, [], 24 * 60 * 60_000)).toEqual([])
+  expect(findSessionByAlias(db, 'leased')?.id).toBe(id)
 })

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -120,30 +120,41 @@ test('fetchUnread excludes already-read messages', () => {
   expect(fetchUnreadForRecipient(db, b)).toHaveLength(0)
 })
 
-test('insertBroadcast fans out to all sessions except sender', () => {
+test('insertBroadcast fans out to the caller-selected recipients', () => {
   const sender = createSession(db, { alias: 'sender' })
   const r1 = createSession(db, { alias: 'r1' })
   const r2 = createSession(db, { alias: 'r2' })
+  const excluded = createSession(db, { alias: 'excluded' })
 
-  const result = insertBroadcast(db, { sender_id: sender, content: 'hello all' })
+  const result = insertBroadcast(db, {
+    sender_id: sender,
+    recipient_ids: [r1, r2],
+    content: 'hello selected recipients',
+  })
 
   expect(result.recipient_count).toBe(2)
   expect(result.broadcast_id).toBeTruthy()
 
   const r1Msgs = fetchUnreadForRecipient(db, r1)
   const r2Msgs = fetchUnreadForRecipient(db, r2)
+  const excludedMsgs = fetchUnreadForRecipient(db, excluded)
   const senderMsgs = fetchUnreadForRecipient(db, sender)
 
   expect(r1Msgs).toHaveLength(1)
   expect(r2Msgs).toHaveLength(1)
+  expect(excludedMsgs).toHaveLength(0)
   expect(senderMsgs).toHaveLength(0)
   expect(r1Msgs[0].broadcast_id).toBe(result.broadcast_id)
   expect(r1Msgs[0].broadcast_id).toBe(r2Msgs[0].broadcast_id)
 })
 
-test('insertBroadcast with no other sessions returns zero recipient_count', () => {
+test('insertBroadcast with an empty recipient list returns zero recipient_count', () => {
   const sender = createSession(db, { alias: 'only' })
-  const result = insertBroadcast(db, { sender_id: sender, content: 'lonely' })
+  const result = insertBroadcast(db, {
+    sender_id: sender,
+    recipient_ids: [],
+    content: 'lonely',
+  })
   expect(result.recipient_count).toBe(0)
 })
 
@@ -168,7 +179,11 @@ test('recallMessage on broadcast deletes all copies', () => {
   const sender = createSession(db, { alias: 's' })
   const r1 = createSession(db, { alias: 'r1' })
   const r2 = createSession(db, { alias: 'r2' })
-  const { broadcast_id } = insertBroadcast(db, { sender_id: sender, content: 'group' })
+  const { broadcast_id } = insertBroadcast(db, {
+    sender_id: sender,
+    recipient_ids: [r1, r2],
+    content: 'group',
+  })
   const oneCopy = fetchUnreadForRecipient(db, r1)[0]
 
   const recalled = recallMessage(db, { message_id: oneCopy.id, caller_id: sender })

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -3,7 +3,7 @@ import { unlinkSync, existsSync, mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Database } from 'bun:sqlite'
-import { openDatabase, createClientSession, createSession, findSessionById, findSessionByAlias, findSessionByClientSessionId, findSessionByCcSessionId, releaseSession, updateLastActivity, insertMessage, fetchUnreadForRecipient, markMessagesRead, insertBroadcast, recallMessage, listAllSessions, deleteExpiredMessages, releaseStaleActiveSessions } from '../db'
+import { openDatabase, createClientSession, createSession, findSessionById, findSessionByAlias, findSessionByClientSessionId, findSessionByCcSessionId, registerClientSession, unregisterClientSession, releaseSession, updateLastActivity, insertMessage, fetchUnreadForRecipient, markMessagesRead, insertBroadcast, recallMessage, listAllSessions, deleteExpiredMessages, releaseStaleActiveSessions } from '../db'
 
 const TEST_DB = ':memory:'
 let db: Database
@@ -262,6 +262,7 @@ test('migration upgrades Phase 2.5 schema without losing data', () => {
   expect(sessionColumns).toContain('client_session_id')
   expect(sessionColumns).toContain('cwd')
   expect(sessionColumns).toContain('last_seen_at')
+  expect(sessionColumns).toContain('generation')
   expect(sessionColumns).not.toContain('cc_session_id')
 
   const sessions = migrated.query<{
@@ -274,9 +275,10 @@ test('migration upgrades Phase 2.5 schema without losing data', () => {
     released_at: string | null
     cwd: string | null
     last_seen_at: string | null
+    generation: number
   }, []>(`
     SELECT id, alias, client_kind, client_session_id, created_at,
-           last_activity, released_at, cwd, last_seen_at
+           last_activity, released_at, cwd, last_seen_at, generation
     FROM sessions
     ORDER BY id
   `).all()
@@ -291,6 +293,7 @@ test('migration upgrades Phase 2.5 schema without losing data', () => {
       released_at: null,
       cwd: null,
       last_seen_at: null,
+      generation: 1,
     },
     {
       id: 'released-id',
@@ -302,6 +305,7 @@ test('migration upgrades Phase 2.5 schema without losing data', () => {
       released_at: '2026-04-16T02:00:00Z',
       cwd: null,
       last_seen_at: null,
+      generation: 1,
     },
   ])
 
@@ -341,6 +345,95 @@ test('migration upgrades Phase 2.5 schema without losing data', () => {
 
   migrated.close()
   rmSync(tmp, { recursive: true, force: true })
+})
+
+test('registerClientSession upserts identity and increments generation', () => {
+  const first = registerClientSession(db, {
+    alias: 'codex-one',
+    client_kind: 'codex',
+    client_session_id: 'thread-123',
+    cwd: '/workspace/one',
+  })
+  expect(first.generation).toBe(1)
+
+  const second = registerClientSession(db, {
+    alias: 'codex-two',
+    client_kind: 'codex',
+    client_session_id: 'thread-123',
+    cwd: '/workspace/two',
+  })
+  expect(second.id).toBe(first.id)
+  expect(second.alias).toBe('codex-two')
+  expect(second.cwd).toBe('/workspace/two')
+  expect(second.generation).toBe(2)
+
+  releaseSession(db, first.id)
+  const third = registerClientSession(db, {
+    alias: 'codex-three',
+    client_kind: 'codex',
+    client_session_id: 'thread-123',
+    cwd: '/workspace/three',
+  })
+  expect(third.id).toBe(first.id)
+  expect(third.released_at).toBeNull()
+  expect(third.generation).toBe(3)
+})
+
+test('registerClientSession prefers the active row over released identity history', () => {
+  const releasedId = createClientSession(db, {
+    alias: 'old-instance',
+    client_kind: 'codex',
+    client_session_id: 'identity-with-history',
+  })
+  releaseSession(db, releasedId)
+  const activeId = createClientSession(db, {
+    alias: 'current-instance',
+    client_kind: 'codex',
+    client_session_id: 'identity-with-history',
+  })
+
+  const registered = registerClientSession(db, {
+    alias: 'renamed-current-instance',
+    client_kind: 'codex',
+    client_session_id: 'identity-with-history',
+    cwd: '/workspace',
+  })
+  expect(registered.id).toBe(activeId)
+  expect(registered.generation).toBe(2)
+  expect(findSessionById(db, releasedId)?.released_at).not.toBeNull()
+})
+
+test('unregisterClientSession rejects a stale generation without releasing active row', () => {
+  const first = registerClientSession(db, {
+    alias: 'generation-one',
+    client_kind: 'codex',
+    client_session_id: 'thread-generation',
+    cwd: '/workspace',
+  })
+  const second = registerClientSession(db, {
+    alias: 'generation-two',
+    client_kind: 'codex',
+    client_session_id: 'thread-generation',
+    cwd: '/workspace',
+  })
+
+  expect(unregisterClientSession(db, {
+    client_kind: 'codex',
+    client_session_id: 'thread-generation',
+    generation: first.generation,
+  })).toBe('generation_mismatch')
+  expect(findSessionById(db, second.id)?.released_at).toBeNull()
+
+  expect(unregisterClientSession(db, {
+    client_kind: 'codex',
+    client_session_id: 'thread-generation',
+    generation: second.generation,
+  })).toBe('released')
+  expect(unregisterClientSession(db, {
+    client_kind: 'codex',
+    client_session_id: 'thread-generation',
+    generation: second.generation,
+  })).toBe('already_released')
 })
 
 test('client session helpers use client_kind as an identity namespace', () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -3,7 +3,7 @@ import { unlinkSync, existsSync, mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Database } from 'bun:sqlite'
-import { openDatabase, createSession, findSessionById, findSessionByAlias, findSessionByCcSessionId, releaseSession, updateLastActivity, insertMessage, fetchUnreadForRecipient, markMessagesRead, insertBroadcast, recallMessage, listAllSessions, deleteExpiredMessages, releaseStaleActiveSessions } from '../db'
+import { openDatabase, createClientSession, createSession, findSessionById, findSessionByAlias, findSessionByClientSessionId, findSessionByCcSessionId, releaseSession, updateLastActivity, insertMessage, fetchUnreadForRecipient, markMessagesRead, insertBroadcast, recallMessage, listAllSessions, deleteExpiredMessages, releaseStaleActiveSessions } from '../db'
 
 const TEST_DB = ':memory:'
 let db: Database
@@ -207,18 +207,27 @@ test('deleteExpiredMessages keeps unread messages regardless of age', () => {
   expect(remaining).toHaveLength(1)
 })
 
-test('openDatabase drops old Phase 1 sessions table if cc_session_id column missing', () => {
+test('migration upgrades Phase 2.5 schema without losing data', () => {
   const tmp = mkdtempSync(join(tmpdir(), 'switchboard-migration-'))
-  const dbPath = join(tmp, 'phase1.db')
+  const dbPath = join(tmp, 'phase2-5.db')
 
   const rawDb = new Database(dbPath)
+  rawDb.exec('PRAGMA foreign_keys = ON')
   rawDb.exec(`
     CREATE TABLE sessions (
         id TEXT PRIMARY KEY,
-        alias TEXT UNIQUE,
+        alias TEXT,
+        cc_session_id TEXT,
         created_at TEXT NOT NULL,
-        last_activity TEXT NOT NULL
+        last_activity TEXT NOT NULL,
+        released_at TEXT
     );
+    CREATE UNIQUE INDEX idx_sessions_alias_active
+        ON sessions(alias)
+        WHERE alias IS NOT NULL AND released_at IS NULL;
+    CREATE UNIQUE INDEX idx_sessions_cc_session_id_active
+        ON sessions(cc_session_id)
+        WHERE cc_session_id IS NOT NULL AND released_at IS NULL;
     CREATE TABLE messages (
         id TEXT PRIMARY KEY,
         sender_id TEXT NOT NULL,
@@ -226,32 +235,165 @@ test('openDatabase drops old Phase 1 sessions table if cc_session_id column miss
         broadcast_id TEXT,
         content TEXT NOT NULL,
         created_at TEXT NOT NULL,
-        read_at TEXT
+        read_at TEXT,
+        FOREIGN KEY (sender_id) REFERENCES sessions(id),
+        FOREIGN KEY (recipient_id) REFERENCES sessions(id)
     );
   `)
-  rawDb.exec(`INSERT INTO sessions (id, alias, created_at, last_activity) VALUES ('old-id', 'old-alias', '2026-04-16T00:00:00Z', '2026-04-16T00:00:00Z')`)
+  rawDb.exec(`
+    INSERT INTO sessions
+      (id, alias, cc_session_id, created_at, last_activity, released_at)
+    VALUES
+      ('active-id', 'active-alias', 'shared-client-id', '2026-04-16T00:00:00Z', '2026-04-16T01:00:00Z', NULL),
+      ('released-id', NULL, 'released-client-id', '2026-04-15T00:00:00Z', '2026-04-15T01:00:00Z', '2026-04-16T02:00:00Z');
+    INSERT INTO messages
+      (id, sender_id, recipient_id, broadcast_id, content, created_at, read_at)
+    VALUES
+      ('message-id', 'released-id', 'active-id', NULL, 'keep me', '2026-04-16T03:00:00Z', NULL);
+  `)
   rawDb.close()
 
-  const db = openDatabase(dbPath)
-  const cols = db.query<{ name: string }, []>(`PRAGMA table_info(sessions)`).all()
-  const colNames = cols.map((c) => c.name)
-  expect(colNames).toContain('cc_session_id')
-  expect(colNames).toContain('released_at')
-  const rows = db.query('SELECT id FROM sessions').all()
-  expect(rows).toHaveLength(0)
-  db.close()
+  const migrated = openDatabase(dbPath)
+  const sessionColumns = migrated
+    .query<{ name: string }, []>(`PRAGMA table_info(sessions)`)
+    .all()
+    .map((column) => column.name)
+  expect(sessionColumns).toContain('client_kind')
+  expect(sessionColumns).toContain('client_session_id')
+  expect(sessionColumns).toContain('cwd')
+  expect(sessionColumns).toContain('last_seen_at')
+  expect(sessionColumns).not.toContain('cc_session_id')
+
+  const sessions = migrated.query<{
+    id: string
+    alias: string | null
+    client_kind: string
+    client_session_id: string | null
+    created_at: string
+    last_activity: string
+    released_at: string | null
+    cwd: string | null
+    last_seen_at: string | null
+  }, []>(`
+    SELECT id, alias, client_kind, client_session_id, created_at,
+           last_activity, released_at, cwd, last_seen_at
+    FROM sessions
+    ORDER BY id
+  `).all()
+  expect(sessions).toEqual([
+    {
+      id: 'active-id',
+      alias: 'active-alias',
+      client_kind: 'claude_code',
+      client_session_id: 'shared-client-id',
+      created_at: '2026-04-16T00:00:00Z',
+      last_activity: '2026-04-16T01:00:00Z',
+      released_at: null,
+      cwd: null,
+      last_seen_at: null,
+    },
+    {
+      id: 'released-id',
+      alias: null,
+      client_kind: 'claude_code',
+      client_session_id: 'released-client-id',
+      created_at: '2026-04-15T00:00:00Z',
+      last_activity: '2026-04-15T01:00:00Z',
+      released_at: '2026-04-16T02:00:00Z',
+      cwd: null,
+      last_seen_at: null,
+    },
+  ])
+
+  const message = migrated.query<{
+    id: string
+    sender_id: string
+    recipient_id: string
+    content: string
+    reply_to: string | null
+  }, []>(`
+    SELECT id, sender_id, recipient_id, content, reply_to
+    FROM messages
+  `).get()
+  expect(message).toEqual({
+    id: 'message-id',
+    sender_id: 'released-id',
+    recipient_id: 'active-id',
+    content: 'keep me',
+    reply_to: null,
+  })
+
+  migrated.query(`
+    INSERT INTO sessions
+      (id, alias, client_kind, client_session_id, created_at, last_activity, released_at)
+    VALUES (?, ?, ?, ?, ?, ?, NULL)
+  `).run('codex-id', 'codex-alias', 'codex', 'shared-client-id', '2026-04-16T04:00:00Z', '2026-04-16T04:00:00Z')
+  expect(() => migrated.query(`
+    INSERT INTO sessions
+      (id, alias, client_kind, client_session_id, created_at, last_activity, released_at)
+    VALUES (?, ?, ?, ?, ?, ?, NULL)
+  `).run('duplicate-id', 'duplicate-alias', 'claude_code', 'shared-client-id', '2026-04-16T05:00:00Z', '2026-04-16T05:00:00Z')).toThrow()
+  migrated.query(`
+    INSERT INTO sessions
+      (id, alias, client_kind, client_session_id, created_at, last_activity, released_at)
+    VALUES (?, ?, ?, ?, ?, ?, NULL)
+  `).run('reused-id', 'reused-alias', 'claude_code', 'released-client-id', '2026-04-16T06:00:00Z', '2026-04-16T06:00:00Z')
+
+  migrated.close()
   rmSync(tmp, { recursive: true, force: true })
+})
+
+test('client session helpers use client_kind as an identity namespace', () => {
+  const claude = createClientSession(db, {
+    alias: 'claude-peer',
+    client_kind: 'claude_code',
+    client_session_id: 'shared-id',
+    cwd: '/workspace/claude',
+  })
+  const codex = createClientSession(db, {
+    alias: 'codex-peer',
+    client_kind: 'codex',
+    client_session_id: 'shared-id',
+    cwd: '/workspace/codex',
+  })
+
+  expect(findSessionByClientSessionId(db, 'claude_code', 'shared-id')?.id).toBe(claude)
+  expect(findSessionByClientSessionId(db, 'codex', 'shared-id')?.id).toBe(codex)
+  expect(findSessionByClientSessionId(db, 'external', 'shared-id')).toBeNull()
+  expect(findSessionById(db, codex)?.cwd).toBe('/workspace/codex')
+})
+
+test('insertMessage stores nullable reply_to', () => {
+  const sender = createSession(db, { alias: 'reply-sender' })
+  const recipient = createSession(db, { alias: 'reply-recipient' })
+  const root = insertMessage(db, {
+    sender_id: sender,
+    recipient_id: recipient,
+    broadcast_id: null,
+    content: 'root',
+  })
+  insertMessage(db, {
+    sender_id: sender,
+    recipient_id: recipient,
+    broadcast_id: null,
+    content: 'reply',
+    reply_to: root,
+  })
+
+  const messages = fetchUnreadForRecipient(db, recipient)
+  expect(messages.map((message) => message.reply_to)).toEqual([null, root])
 })
 
 test('createSession accepts optional cc_session_id', () => {
   const db = openDatabase(':memory:')
   const id = createSession(db, { alias: 'my-role', cc_session_id: 'cc-abc-123' })
   const row = db
-    .query<{ id: string; cc_session_id: string | null }, [string]>(
-      `SELECT id, cc_session_id FROM sessions WHERE id = ?`,
+    .query<{ id: string; client_kind: string; client_session_id: string | null }, [string]>(
+      `SELECT id, client_kind, client_session_id FROM sessions WHERE id = ?`,
     )
     .get(id)
-  expect(row?.cc_session_id).toBe('cc-abc-123')
+  expect(row?.client_kind).toBe('claude_code')
+  expect(row?.client_session_id).toBe('cc-abc-123')
   db.close()
 })
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -81,11 +81,9 @@ test('send 1-to-1: recipient gets message on read_messages', async () => {
   })
   const sendParsed = JSON.parse((sendResult.content as any[])[0].text)
   expect(typeof sendParsed.message_id).toBe('string')
-  // Phase 1 recipient (registered without cc_session_id) has no poller
-  // process, so delivered_notification is false — the message still lands
-  // in the DB and shows up on read_messages below, which is the real
-  // correctness signal. See poller.isPollerAlive for the semantics.
-  expect(sendParsed.delivered_notification).toBe(false)
+  // A successful MCP push is now sufficient for delivered_notification,
+  // even when this legacy anonymous identity has no poller lease.
+  expect(sendParsed.delivered_notification).toBe(true)
 
   const readResult = await recipient.callTool({ name: 'read_messages', arguments: {} })
   const readParsed = JSON.parse((readResult.content as any[])[0].text)
@@ -298,6 +296,55 @@ test('/poll returns no-session when cc_session_id is unknown', async () => {
   expect(body.status).toBe('no-session')
 })
 
+test('/poll resolves client identity by client_kind namespace', async () => {
+  await postJson(REGISTER_URL, {
+    alias: 'poll-codex-shared',
+    client_kind: 'codex',
+    client_session_id: 'poll-shared-id',
+    cwd: '/workspace/codex',
+  })
+  const claude = await makeClient('poll-claude-shared')
+  await claude.callTool({
+    name: 'register',
+    arguments: { role: 'poll-claude-shared', cc_session_id: 'poll-shared-id' },
+  })
+
+  const codexPoll = fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=poll-shared-id&timeout_s=5`,
+  )
+  await new Promise((r) => setTimeout(r, 80))
+
+  const sender = await makeClient('poll-kind-sender')
+  await sender.callTool({ name: 'register', arguments: { role: 'poll-kind-sender' } })
+  await sender.callTool({
+    name: 'send',
+    arguments: { to: 'poll-codex-shared', message: 'codex only' },
+  })
+
+  const body = await (await codexPoll).json()
+  expect(body.status).toBe('unread')
+  expect(body.alias).toBe('poll-codex-shared')
+
+  await sender.close()
+  await claude.close()
+})
+
+test('/poll validates canonical client identity parameters', async () => {
+  const missingKind = await fetch(`${POLL_URL}?client_session_id=some-id&timeout_s=1`)
+  expect(missingKind.status).toBe(400)
+  expect(await missingKind.text()).toContain('client_kind')
+
+  const invalidKind = await fetch(
+    `${POLL_URL}?client_kind=other&client_session_id=some-id&timeout_s=1`,
+  )
+  expect(invalidKind.status).toBe(400)
+
+  const ambiguous = await fetch(
+    `${POLL_URL}?cc_session_id=some-id&client_kind=codex&client_session_id=some-id&timeout_s=1`,
+  )
+  expect(ambiguous.status).toBe(400)
+})
+
 test('/poll returns unread immediately when messages are already waiting', async () => {
   const sender = await makeClient('poll-sender-imm')
   await sender.callTool({
@@ -392,16 +439,58 @@ test('send to a recipient currently long-polling reports delivered_notification:
   await recipient.close()
 })
 
+test('/poll renews a lease used by list_sessions and delivered_notification', async () => {
+  await postJson(REGISTER_URL, {
+    alias: 'leased-codex',
+    client_kind: 'codex',
+    client_session_id: 'leased-codex-id',
+    cwd: '/workspace',
+  })
+
+  const observer = await makeClient('lease-observer')
+  await observer.callTool({ name: 'register', arguments: { role: 'lease-observer' } })
+  const before = JSON.parse(((await observer.callTool({
+    name: 'list_sessions',
+    arguments: {},
+  })).content as any[])[0].text)
+  expect(before.find((s: any) => s.alias === 'leased-codex')?.online).toBe(false)
+
+  const poll = fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=leased-codex-id&timeout_s=1`,
+  )
+  await new Promise((r) => setTimeout(r, 80))
+  const during = JSON.parse(((await observer.callTool({
+    name: 'list_sessions',
+    arguments: {},
+  })).content as any[])[0].text)
+  expect(during.find((s: any) => s.alias === 'leased-codex')?.online).toBe(true)
+  await poll
+
+  const send = JSON.parse(((await observer.callTool({
+    name: 'send',
+    arguments: { to: 'leased-codex', message: 'lease wake' },
+  })).content as any[])[0].text)
+  expect(send.delivered_notification).toBe(true)
+
+  const broadcast = JSON.parse(((await observer.callTool({
+    name: 'broadcast',
+    arguments: { message: 'lease broadcast' },
+  })).content as any[])[0].text)
+  expect(broadcast.recipient_count).toBe(1)
+  expect(broadcast.notified_count).toBe(1)
+
+  await observer.close()
+})
+
 test('delivered_notification is false when only a legacy state file exists (no live /poll)', async () => {
-  // Regression: canAutoWake used to also trust poller.ts's state file, so a
-  // stale file whose pid had been reused as an unrelated process would make
-  // delivered_notification falsely report true. The shim does not write
-  // state files, so we now only trust waiters.isPolling. This test guards
-  // against re-introducing the fallback.
+  // Regression: canAutoWake used to trust poller.ts's state file, so a stale
+  // file whose pid had been reused by another process could report delivery.
+  // The shared online predicate intentionally ignores state files.
   const fs = await import('node:fs')
   const os = await import('node:os')
   const path = await import('node:path')
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sb-statefile-'))
+  const originalStateDir = process.env.SWITCHBOARD_POLLER_STATE_DIR
   try {
     // Stash a state file pointing at our own (live) pid — the old code path
     // would accept this as "alive".
@@ -409,10 +498,12 @@ test('delivered_notification is false when only a legacy state file exists (no l
     const stateFile = path.join(tmpDir, `switchboard-poller-${ccSessionId}.state`)
     fs.writeFileSync(stateFile, JSON.stringify({ pid: process.pid, cc_session_id: ccSessionId, started_at: new Date().toISOString() }))
 
-    const recipient = await makeClient('legacy-statefile-recip')
-    await recipient.callTool({
-      name: 'register',
-      arguments: { role: 'legacy-rcp', cc_session_id: ccSessionId },
+    process.env.SWITCHBOARD_POLLER_STATE_DIR = tmpDir
+    await postJson(REGISTER_URL, {
+      alias: 'legacy-rcp',
+      client_kind: 'claude_code',
+      client_session_id: ccSessionId,
+      cwd: '/workspace',
     })
 
     const sender = await makeClient('legacy-statefile-sender')
@@ -424,8 +515,12 @@ test('delivered_notification is false when only a legacy state file exists (no l
     expect(sendResult.delivered_notification).toBe(false)
 
     await sender.close()
-    await recipient.close()
   } finally {
+    if (originalStateDir === undefined) {
+      delete process.env.SWITCHBOARD_POLLER_STATE_DIR
+    } else {
+      process.env.SWITCHBOARD_POLLER_STATE_DIR = originalStateDir
+    }
     fs.rmSync(tmpDir, { recursive: true, force: true })
   }
 })
@@ -453,6 +548,34 @@ test('alias is released on disconnect, new client can reclaim the name', async (
   expect(second.alias).toBe('reclaimable')
   expect(second.session_id).not.toBe(first.session_id)
   await c2.close()
+})
+
+test('closing an older MCP transport does not release a newer generation', async () => {
+  const oldClient = await makeClient('generation-old')
+  const oldRegistration = JSON.parse(((await oldClient.callTool({
+    name: 'register',
+    arguments: { role: 'generation-old', cc_session_id: 'generation-shared' },
+  })).content as any[])[0].text)
+
+  const newClient = await makeClient('generation-new')
+  const newRegistration = JSON.parse(((await newClient.callTool({
+    name: 'register',
+    arguments: { role: 'generation-current', cc_session_id: 'generation-shared' },
+  })).content as any[])[0].text)
+  expect(newRegistration.session_id).toBe(oldRegistration.session_id)
+
+  await oldClient.close()
+  await new Promise((r) => setTimeout(r, 50))
+
+  const sessions = JSON.parse(((await newClient.callTool({
+    name: 'list_sessions',
+    arguments: {},
+  })).content as any[])[0].text)
+  const current = sessions.find((s: any) => s.session_id === newRegistration.session_id)
+  expect(current?.alias).toBe('generation-current')
+  expect(current?.online).toBe(true)
+
+  await newClient.close()
 })
 
 test('released session row stays queryable by id (messages FK preserved)', async () => {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -130,6 +130,198 @@ test('broadcast fans out to all other sessions', async () => {
   await r2.close()
 })
 
+test('broadcast tool advertises all, same_kind, and same_cwd scopes with all as default', async () => {
+  const client = await makeClient('bcast-schema')
+  const tools = await client.listTools()
+  const broadcast = tools.tools.find((tool) => tool.name === 'broadcast')
+  const scope = (broadcast?.inputSchema.properties as any)?.scope
+
+  expect(scope.enum).toEqual(['all', 'same_kind', 'same_cwd'])
+  expect(scope.default).toBe('all')
+
+  await client.close()
+})
+
+for (const testCase of [
+  {
+    scope: 'all',
+    queuedKind: 'external',
+    queuedCwd: '/workspace/other',
+    onlineCodexDelivered: true,
+    recipientCount: 2,
+    notifiedCount: 1,
+  },
+  {
+    scope: 'same_kind',
+    queuedKind: 'claude_code',
+    queuedCwd: '/workspace/other',
+    onlineCodexDelivered: false,
+    recipientCount: 1,
+    notifiedCount: 0,
+  },
+  {
+    scope: 'same_cwd',
+    queuedKind: 'external',
+    queuedCwd: '/workspace/shared',
+    onlineCodexDelivered: true,
+    recipientCount: 2,
+    notifiedCount: 1,
+  },
+] as const) {
+  test(`broadcast scope=${testCase.scope} filters recipients and never queues offline codex`, async () => {
+    const senderIdentity = `scope-sender-${testCase.scope}`
+    await postJson(REGISTER_URL, {
+      alias: `scope-sender-${testCase.scope}`,
+      client_kind: 'claude_code',
+      client_session_id: senderIdentity,
+      cwd: '/workspace/shared',
+    })
+    const sender = await makeClient(`scope-sender-mcp-${testCase.scope}`)
+    await sender.callTool({
+      name: 'register',
+      arguments: {
+        role: `scope-sender-${testCase.scope}`,
+        cc_session_id: senderIdentity,
+      },
+    })
+
+    const onlineCodexId = `online-codex-${testCase.scope}`
+    const offlineCodexId = `offline-codex-${testCase.scope}`
+    await postJson(REGISTER_URL, {
+      alias: onlineCodexId,
+      client_kind: 'codex',
+      client_session_id: onlineCodexId,
+      cwd: '/workspace/shared',
+    })
+    await postJson(REGISTER_URL, {
+      alias: offlineCodexId,
+      client_kind: 'codex',
+      client_session_id: offlineCodexId,
+      cwd: '/workspace/shared',
+    })
+    await postJson(REGISTER_URL, {
+      alias: `queued-${testCase.scope}`,
+      client_kind: testCase.queuedKind,
+      client_session_id: `queued-${testCase.scope}`,
+      cwd: testCase.queuedCwd,
+    })
+
+    const onlinePoll = fetch(
+      `${POLL_URL}?client_kind=codex&client_session_id=${onlineCodexId}&timeout_s=1`,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    const result = JSON.parse(((await sender.callTool({
+      name: 'broadcast',
+      arguments: {
+        message: `scope ${testCase.scope}`,
+        scope: testCase.scope,
+      },
+    })).content as any[])[0].text)
+    expect(result.recipient_count).toBe(testCase.recipientCount)
+    expect(result.notified_count).toBe(testCase.notifiedCount)
+
+    const onlinePollBody = await (await onlinePoll).json()
+    expect(onlinePollBody.status).toBe(
+      testCase.onlineCodexDelivered ? 'unread' : 'timeout',
+    )
+
+    // An offline codex peer must not receive a mailbox row. Polling only after
+    // the broadcast makes it online too late and must still return timeout.
+    const offlinePoll = await fetch(
+      `${POLL_URL}?client_kind=codex&client_session_id=${offlineCodexId}&timeout_s=1`,
+    )
+    expect((await offlinePoll.json()).status).toBe('timeout')
+
+    // Claude Code and external peers keep the existing durable-mailbox
+    // behavior: they were offline at send time but can read the queued row
+    // when they poll later.
+    const queuedPoll = await fetch(
+      `${POLL_URL}?client_kind=${testCase.queuedKind}` +
+      `&client_session_id=queued-${testCase.scope}&timeout_s=1`,
+    )
+    expect((await queuedPoll.json()).status).toBe('unread')
+
+    await sender.close()
+  })
+}
+
+test('broadcast scope=same_cwd does not match any recipient when sender cwd is NULL', async () => {
+  const sender = await makeClient('null-cwd-sender')
+  await sender.callTool({
+    name: 'register',
+    arguments: { role: 'null-cwd-sender', cc_session_id: 'null-cwd-sender' },
+  })
+  await postJson(REGISTER_URL, {
+    alias: 'non-null-cwd-recipient',
+    client_kind: 'external',
+    client_session_id: 'non-null-cwd-recipient',
+    cwd: '/workspace/shared',
+  })
+
+  const result = JSON.parse(((await sender.callTool({
+    name: 'broadcast',
+    arguments: { message: 'NULL cwd never matches', scope: 'same_cwd' },
+  })).content as any[])[0].text)
+  expect(result.recipient_count).toBe(0)
+  expect(result.notified_count).toBe(0)
+
+  await sender.close()
+})
+
+test('broadcast scope=same_cwd excludes a NULL recipient cwd when sender cwd is non-NULL', async () => {
+  await postJson(REGISTER_URL, {
+    alias: 'non-null-cwd-sender',
+    client_kind: 'claude_code',
+    client_session_id: 'non-null-cwd-sender',
+    cwd: '/workspace/shared',
+  })
+  const sender = await makeClient('non-null-cwd-sender-mcp')
+  await sender.callTool({
+    name: 'register',
+    arguments: {
+      role: 'non-null-cwd-sender',
+      cc_session_id: 'non-null-cwd-sender',
+    },
+  })
+  await postJson(REGISTER_URL, {
+    alias: 'null-cwd-recipient',
+    client_kind: 'external',
+    client_session_id: 'null-cwd-recipient',
+    cwd: null,
+  })
+  await postJson(REGISTER_URL, {
+    alias: 'matching-cwd-recipient',
+    client_kind: 'external',
+    client_session_id: 'matching-cwd-recipient',
+    cwd: '/workspace/shared',
+  })
+
+  const result = JSON.parse(((await sender.callTool({
+    name: 'broadcast',
+    arguments: { message: 'NULL recipient cwd never matches', scope: 'same_cwd' },
+  })).content as any[])[0].text)
+  expect(result.recipient_count).toBe(1)
+  expect(result.notified_count).toBe(0)
+
+  await sender.close()
+})
+
+test('broadcast rejects a scope outside the advertised enum', async () => {
+  const sender = await makeClient('invalid-scope-sender')
+  await sender.callTool({
+    name: 'register',
+    arguments: { role: 'invalid-scope-sender' },
+  })
+
+  await expect(sender.callTool({
+    name: 'broadcast',
+    arguments: { message: 'invalid scope', scope: 'nearby' },
+  })).rejects.toThrow(/scope must be one of/)
+
+  await sender.close()
+})
+
 test('read_messages marks as read (second call returns empty)', async () => {
   const a = await makeClient('read-a')
   const b = await makeClient('read-b')

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -688,6 +688,8 @@ test('/monitor abort releases the waiter so cancelAll isn\'t stuck on shutdown',
 // --- local external sender endpoint ---
 
 const EXTERNAL_SEND_URL = `http://127.0.0.1:${TEST_PORT}/external/send`
+const REGISTER_URL = `http://127.0.0.1:${TEST_PORT}/register`
+const UNREGISTER_URL = `http://127.0.0.1:${TEST_PORT}/unregister`
 
 test('/external/send delivers and wakes a registered Claude Code session', async () => {
   const recipient = await makeClient('external-recip')
@@ -724,4 +726,188 @@ test('/external/send delivers and wakes a registered Claude Code session', async
   expect(readParsed.messages[0].sender_alias).toBe('codex')
 
   await recipient.close()
+})
+
+async function postJson(url: string, body: unknown): Promise<Response> {
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+test('HTTP register upserts active and released peer sessions with increasing generation', async () => {
+  const firstResp = await postJson(REGISTER_URL, {
+    alias: 'http-codex-one',
+    client_kind: 'codex',
+    client_session_id: 'codex-thread-1',
+    cwd: '/workspace/one',
+  })
+  expect(firstResp.status).toBe(200)
+  const first = await firstResp.json()
+  expect(first).toEqual({
+    session_id: expect.any(String),
+    alias: 'http-codex-one',
+    generation: 1,
+  })
+
+  const secondResp = await postJson(REGISTER_URL, {
+    alias: 'http-codex-two',
+    client_kind: 'codex',
+    client_session_id: 'codex-thread-1',
+    cwd: '/workspace/two',
+  })
+  expect(secondResp.status).toBe(200)
+  const second = await secondResp.json()
+  expect(second).toEqual({
+    session_id: first.session_id,
+    alias: 'http-codex-two',
+    generation: 2,
+  })
+
+  const releaseResp = await postJson(UNREGISTER_URL, {
+    client_kind: 'codex',
+    client_session_id: 'codex-thread-1',
+    generation: second.generation,
+  })
+  expect(releaseResp.status).toBe(200)
+  expect(await releaseResp.json()).toEqual({ status: 'released' })
+
+  const thirdResp = await postJson(REGISTER_URL, {
+    alias: 'http-codex-three',
+    client_kind: 'codex',
+    client_session_id: 'codex-thread-1',
+    cwd: '/workspace/three',
+  })
+  expect(thirdResp.status).toBe(200)
+  const third = await thirdResp.json()
+  expect(third).toEqual({
+    session_id: first.session_id,
+    alias: 'http-codex-three',
+    generation: 3,
+  })
+})
+
+test('HTTP unregister rejects stale generation without killing the current instance', async () => {
+  const first = await (await postJson(REGISTER_URL, {
+    alias: 'stale-token-one',
+    client_kind: 'external',
+    client_session_id: 'external-thread-1',
+    cwd: '/workspace',
+  })).json()
+  const current = await (await postJson(REGISTER_URL, {
+    alias: 'stale-token-current',
+    client_kind: 'external',
+    client_session_id: 'external-thread-1',
+    cwd: '/workspace',
+  })).json()
+
+  const staleResp = await postJson(UNREGISTER_URL, {
+    client_kind: 'external',
+    client_session_id: 'external-thread-1',
+    generation: first.generation,
+  })
+  expect(staleResp.status).toBe(409)
+  expect(await staleResp.json()).toEqual({
+    error: 'generation mismatch: current generation is 2',
+  })
+
+  const currentResp = await postJson(UNREGISTER_URL, {
+    client_kind: 'external',
+    client_session_id: 'external-thread-1',
+    generation: current.generation,
+  })
+  expect(currentResp.status).toBe(200)
+  expect(await currentResp.json()).toEqual({ status: 'released' })
+})
+
+test('HTTP register reports an active alias conflict', async () => {
+  await postJson(REGISTER_URL, {
+    alias: 'http-taken-alias',
+    client_kind: 'codex',
+    client_session_id: 'alias-owner',
+    cwd: '/workspace',
+  })
+
+  const conflictResp = await postJson(REGISTER_URL, {
+    alias: 'http-taken-alias',
+    client_kind: 'external',
+    client_session_id: 'alias-contender',
+    cwd: '/workspace',
+  })
+  expect(conflictResp.status).toBe(409)
+  expect(await conflictResp.json()).toEqual({
+    error: 'alias already taken: http-taken-alias',
+  })
+})
+
+test('HTTP register validates JSON, required fields, and client_kind', async () => {
+  const invalidJson = await fetch(REGISTER_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{',
+  })
+  expect(invalidJson.status).toBe(400)
+  expect(await invalidJson.json()).toEqual({ error: 'invalid JSON body' })
+
+  const invalidCases: Array<{ body: unknown; error: string }> = [
+    { body: [], error: 'request body must be a JSON object' },
+    {
+      body: { client_kind: 'codex', client_session_id: 'thread', cwd: '/workspace' },
+      error: 'alias is required and must be a non-empty string',
+    },
+    {
+      body: { alias: 'peer', client_kind: 'other', client_session_id: 'thread', cwd: '/workspace' },
+      error: 'client_kind must be one of: claude_code, codex, external',
+    },
+    {
+      body: { alias: 'peer', client_session_id: 'thread', cwd: '/workspace' },
+      error: 'client_kind must be one of: claude_code, codex, external',
+    },
+    {
+      body: { alias: 'peer', client_kind: 'codex', client_session_id: '   ', cwd: '/workspace' },
+      error: 'client_session_id is required and must be a non-empty string',
+    },
+    {
+      body: { alias: 'peer', client_kind: 'codex', client_session_id: 'thread', cwd: '' },
+      error: 'cwd is required and must be a non-empty string',
+    },
+  ]
+
+  for (const invalidCase of invalidCases) {
+    const resp = await postJson(REGISTER_URL, invalidCase.body)
+    expect(resp.status).toBe(400)
+    expect(await resp.json()).toEqual({ error: invalidCase.error })
+  }
+})
+
+test('HTTP unregister validates identity and generation fields', async () => {
+  const invalidCases: Array<{ body: unknown; error: string }> = [
+    {
+      body: { client_kind: 'other', client_session_id: 'thread', generation: 1 },
+      error: 'client_kind must be one of: claude_code, codex, external',
+    },
+    {
+      body: { client_kind: 'codex', client_session_id: '', generation: 1 },
+      error: 'client_session_id is required and must be a non-empty string',
+    },
+    {
+      body: { client_kind: 'codex', client_session_id: 'thread', generation: 0 },
+      error: 'generation is required and must be a positive integer',
+    },
+    {
+      body: { client_kind: 'codex', client_session_id: 'thread' },
+      error: 'generation is required and must be a positive integer',
+    },
+    {
+      body: { client_kind: 'codex', client_session_id: 'thread', generation: 1.5 },
+      error: 'generation is required and must be a positive integer',
+    },
+  ]
+
+  for (const invalidCase of invalidCases) {
+    const resp = await postJson(UNREGISTER_URL, invalidCase.body)
+    expect(resp.status).toBe(400)
+    expect(await resp.json()).toEqual({ error: invalidCase.error })
+  }
 })

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -550,6 +550,48 @@ test('alias is released on disconnect, new client can reclaim the name', async (
   await c2.close()
 })
 
+test('explicit unregister from an older MCP transport does not release a newer generation', async () => {
+  const oldClient = await makeClient('stale-unreg-old')
+  const oldRegistration = JSON.parse(((await oldClient.callTool({
+    name: 'register',
+    arguments: { role: 'stale-unreg-old', cc_session_id: 'stale-unreg-shared' },
+  })).content as any[])[0].text)
+
+  const newClient = await makeClient('stale-unreg-new')
+  const newRegistration = JSON.parse(((await newClient.callTool({
+    name: 'register',
+    arguments: { role: 'stale-unreg-current', cc_session_id: 'stale-unreg-shared' },
+  })).content as any[])[0].text)
+  expect(newRegistration.session_id).toBe(oldRegistration.session_id)
+
+  // The stale transport actively unregisters — the guard must ignore it.
+  const staleResult = JSON.parse(((await oldClient.callTool({
+    name: 'unregister',
+    arguments: {},
+  })).content as any[])[0].text)
+  expect(staleResult.status).toBe('stale_ignored')
+  expect(staleResult.released_alias).toBeNull()
+
+  const sessions = JSON.parse(((await newClient.callTool({
+    name: 'list_sessions',
+    arguments: {},
+  })).content as any[])[0].text)
+  const current = sessions.find((s: any) => s.session_id === newRegistration.session_id)
+  expect(current?.alias).toBe('stale-unreg-current')
+  expect(current?.online).toBe(true)
+
+  // The current generation's own unregister still releases normally.
+  const currentResult = JSON.parse(((await newClient.callTool({
+    name: 'unregister',
+    arguments: {},
+  })).content as any[])[0].text)
+  expect(currentResult.status).toBe('released')
+  expect(currentResult.released_alias).toBe('stale-unreg-current')
+
+  await oldClient.close()
+  await newClient.close()
+})
+
 test('closing an older MCP transport does not release a newer generation', async () => {
   const oldClient = await makeClient('generation-old')
   const oldRegistration = JSON.parse(((await oldClient.callTool({

--- a/tests/online.test.ts
+++ b/tests/online.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from 'bun:test'
+import { ConnectionRegistry } from '../connections'
+import { isSessionOnline, LEASE_TTL_MS } from '../online'
+import type { SessionRow } from '../types'
+import { UnreadWaiterRegistry } from '../waiters'
+
+function session(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: 'session-id',
+    alias: 'peer',
+    client_kind: 'codex',
+    client_session_id: 'client-id',
+    cwd: null,
+    created_at: '2026-07-24T00:00:00.000Z',
+    last_activity: '2026-07-24T00:00:00.000Z',
+    last_seen_at: null,
+    generation: 1,
+    released_at: null,
+    ...overrides,
+  }
+}
+
+test('session is online while its MCP connection is active', () => {
+  const registry = new ConnectionRegistry()
+  const waiters = new UnreadWaiterRegistry()
+  registry.register('session-id', () => {})
+
+  expect(isSessionOnline(session(), registry, waiters)).toBe(true)
+})
+
+test('session is online while its kind-qualified identity is polling', async () => {
+  const registry = new ConnectionRegistry()
+  const waiters = new UnreadWaiterRegistry()
+  const abort = new AbortController()
+  const waiting = waiters.wait('session-id', 'codex', 'client-id', 60_000, abort.signal)
+
+  expect(isSessionOnline(session(), registry, waiters)).toBe(true)
+  expect(isSessionOnline(session({ client_kind: 'claude_code' }), registry, waiters)).toBe(false)
+
+  abort.abort()
+  await waiting
+})
+
+test('session is online until its lease TTL expires', () => {
+  const registry = new ConnectionRegistry()
+  const waiters = new UnreadWaiterRegistry()
+  const now = Date.parse('2026-07-24T12:00:00.000Z')
+
+  expect(isSessionOnline(
+    session({ last_seen_at: new Date(now - LEASE_TTL_MS + 1).toISOString() }),
+    registry,
+    waiters,
+    now,
+  )).toBe(true)
+  expect(isSessionOnline(
+    session({ last_seen_at: new Date(now - LEASE_TTL_MS).toISOString() }),
+    registry,
+    waiters,
+    now,
+  )).toBe(false)
+})
+
+test('released and unidentified sessions are offline without a live MCP connection', () => {
+  const registry = new ConnectionRegistry()
+  const waiters = new UnreadWaiterRegistry()
+  const now = Date.parse('2026-07-24T12:00:00.000Z')
+  const freshLease = new Date(now - 1_000).toISOString()
+
+  expect(isSessionOnline(session({ released_at: freshLease, last_seen_at: freshLease }), registry, waiters, now)).toBe(false)
+  expect(isSessionOnline(session({ client_session_id: null, last_seen_at: freshLease }), registry, waiters, now)).toBe(false)
+})

--- a/tests/retention.test.ts
+++ b/tests/retention.test.ts
@@ -3,19 +3,35 @@ import { openDatabase, createSession, findSessionByAlias, releaseStaleActiveSess
 import { ConnectionRegistry } from '../connections'
 import { startRetentionLoop } from '../retention'
 
-test('retention sessionsTick releases stale sessions on initial run', () => {
+test('retention sessionsTick releases sessions whose lease expired over 24 hours ago', () => {
   const db = openDatabase(':memory:')
   const registry = new ConnectionRegistry()
 
   const stale = createSession(db, { alias: 'ghost' })
-  // Backdate so stale threshold (5 min in retention.ts) is exceeded.
-  const tenMinAgo = new Date(Date.now() - 10 * 60_000).toISOString()
-  db.query('UPDATE sessions SET last_activity = ? WHERE id = ?').run(tenMinAgo, stale)
+  const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60_000).toISOString()
+  db.query('UPDATE sessions SET last_activity = ? WHERE id = ?').run(twoDaysAgo, stale)
 
   const handle = startRetentionLoop(db, registry)
   try {
     // startRetentionLoop runs tick synchronously once on start.
     expect(findSessionByAlias(db, 'ghost')).toBeNull()
+  } finally {
+    handle.stop()
+    db.close()
+  }
+})
+
+test('retention sessionsTick preserves a lease that expired less than 24 hours ago', () => {
+  const db = openDatabase(':memory:')
+  const registry = new ConnectionRegistry()
+  const recent = createSession(db, { alias: 'recently-offline' })
+  const oneHourAgo = new Date(Date.now() - 60 * 60_000).toISOString()
+  db.query('UPDATE sessions SET last_activity = ?, last_seen_at = ? WHERE id = ?')
+    .run(oneHourAgo, oneHourAgo, recent)
+
+  const handle = startRetentionLoop(db, registry)
+  try {
+    expect(findSessionByAlias(db, 'recently-offline')?.id).toBe(recent)
   } finally {
     handle.stop()
     db.close()

--- a/tests/waiters.test.ts
+++ b/tests/waiters.test.ts
@@ -6,33 +6,33 @@ test('wait resolves immediately when abort signal is already aborted', async () 
   const ac = new AbortController()
   ac.abort()
   const start = Date.now()
-  await reg.wait('sess', 'cc', 10_000, ac.signal)
+  await reg.wait('sess', 'claude_code', 'cc', 10_000, ac.signal)
   expect(Date.now() - start).toBeLessThan(500)
-  expect(reg.isPolling('cc')).toBe(false)
+  expect(reg.isPolling('claude_code', 'cc')).toBe(false)
 })
 
 test('wait resolves when abort signal fires mid-wait', async () => {
   const reg = new UnreadWaiterRegistry()
   const ac = new AbortController()
-  const promise = reg.wait('sess', 'cc', 60_000, ac.signal)
+  const promise = reg.wait('sess', 'claude_code', 'cc', 60_000, ac.signal)
   await Bun.sleep(20)
-  expect(reg.isPolling('cc')).toBe(true)
+  expect(reg.isPolling('claude_code', 'cc')).toBe(true)
   ac.abort()
   await promise
-  expect(reg.isPolling('cc')).toBe(false)
+  expect(reg.isPolling('claude_code', 'cc')).toBe(false)
 })
 
 test('wait resolves on timeout when nothing else happens', async () => {
   const reg = new UnreadWaiterRegistry()
   const start = Date.now()
-  await reg.wait('sess', 'cc', 30, undefined)
+  await reg.wait('sess', 'claude_code', 'cc', 30, undefined)
   expect(Date.now() - start).toBeGreaterThanOrEqual(25)
-  expect(reg.isPolling('cc')).toBe(false)
+  expect(reg.isPolling('claude_code', 'cc')).toBe(false)
 })
 
 test('notify wakes the waiter before the timeout fires', async () => {
   const reg = new UnreadWaiterRegistry()
-  const promise = reg.wait('sess', 'cc', 60_000)
+  const promise = reg.wait('sess', 'claude_code', 'cc', 60_000)
   setTimeout(() => reg.notify('sess'), 20)
   const start = Date.now()
   await promise
@@ -42,10 +42,10 @@ test('notify wakes the waiter before the timeout fires', async () => {
 test('notify only wakes waiters for the matching session id', async () => {
   const reg = new UnreadWaiterRegistry()
   let otherResolved = false
-  const other = reg.wait('other-sess', 'cc-other', 100).then(() => {
+  const other = reg.wait('other-sess', 'claude_code', 'cc-other', 100).then(() => {
     otherResolved = true
   })
-  const target = reg.wait('target-sess', 'cc-target', 60_000)
+  const target = reg.wait('target-sess', 'claude_code', 'cc-target', 60_000)
   reg.notify('target-sess')
   await target
   // other should still be running (until its 100ms timeout)
@@ -55,8 +55,8 @@ test('notify only wakes waiters for the matching session id', async () => {
 
 test('notifyMany wakes every listed session', async () => {
   const reg = new UnreadWaiterRegistry()
-  const p1 = reg.wait('a', 'cc-a', 60_000)
-  const p2 = reg.wait('b', 'cc-b', 60_000)
+  const p1 = reg.wait('a', 'claude_code', 'cc-a', 60_000)
+  const p2 = reg.wait('b', 'claude_code', 'cc-b', 60_000)
   reg.notifyMany(['a', 'b'])
   await Promise.all([p1, p2])
 })
@@ -64,22 +64,57 @@ test('notifyMany wakes every listed session', async () => {
 test('concurrent waiters on the same session are all resolved by a single notify', async () => {
   const reg = new UnreadWaiterRegistry()
   const promises = [
-    reg.wait('sess', 'cc1', 60_000),
-    reg.wait('sess', 'cc2', 60_000),
-    reg.wait('sess', 'cc3', 60_000),
+    reg.wait('sess', 'claude_code', 'cc1', 60_000),
+    reg.wait('sess', 'claude_code', 'cc2', 60_000),
+    reg.wait('sess', 'claude_code', 'cc3', 60_000),
   ]
   reg.notify('sess')
   await Promise.all(promises)
-  expect(reg.isPolling('cc1')).toBe(false)
-  expect(reg.isPolling('cc2')).toBe(false)
-  expect(reg.isPolling('cc3')).toBe(false)
+  expect(reg.isPolling('claude_code', 'cc1')).toBe(false)
+  expect(reg.isPolling('claude_code', 'cc2')).toBe(false)
+  expect(reg.isPolling('claude_code', 'cc3')).toBe(false)
 })
 
 test('cancelAll resolves pending waiters and clears the polling set', async () => {
   const reg = new UnreadWaiterRegistry()
-  const p = reg.wait('sess', 'cc', 60_000)
-  expect(reg.isPolling('cc')).toBe(true)
+  const p = reg.wait('sess', 'claude_code', 'cc', 60_000)
+  expect(reg.isPolling('claude_code', 'cc')).toBe(true)
   reg.cancelAll()
   await p
-  expect(reg.isPolling('cc')).toBe(false)
+  expect(reg.isPolling('claude_code', 'cc')).toBe(false)
+})
+
+test('polling identity includes client_kind to avoid cross-kind collisions', async () => {
+  const reg = new UnreadWaiterRegistry()
+  const claudeAbort = new AbortController()
+  const codexAbort = new AbortController()
+  const claude = reg.wait('claude-session', 'claude_code', 'shared-id', 60_000, claudeAbort.signal)
+  const codex = reg.wait('codex-session', 'codex', 'shared-id', 60_000, codexAbort.signal)
+
+  expect(reg.isPolling('claude_code', 'shared-id')).toBe(true)
+  expect(reg.isPolling('codex', 'shared-id')).toBe(true)
+
+  claudeAbort.abort()
+  await claude
+  expect(reg.isPolling('claude_code', 'shared-id')).toBe(false)
+  expect(reg.isPolling('codex', 'shared-id')).toBe(true)
+
+  codexAbort.abort()
+  await codex
+})
+
+test('one completed wait does not clear another wait for the same client identity', async () => {
+  const reg = new UnreadWaiterRegistry()
+  const firstAbort = new AbortController()
+  const secondAbort = new AbortController()
+  const first = reg.wait('session', 'codex', 'same-id', 60_000, firstAbort.signal)
+  const second = reg.wait('session', 'codex', 'same-id', 60_000, secondAbort.signal)
+
+  firstAbort.abort()
+  await first
+  expect(reg.isPolling('codex', 'same-id')).toBe(true)
+
+  secondAbort.abort()
+  await second
+  expect(reg.isPolling('codex', 'same-id')).toBe(false)
 })

--- a/types.ts
+++ b/types.ts
@@ -1,14 +1,18 @@
 // All shared types for switchboard. No runtime code here.
 
 export type SessionId = string  // UUID
+export type ClientKind = 'claude_code' | 'codex' | 'external'
 
 export interface SessionRow {
   id: SessionId
   alias: string | null
-  cc_session_id?: string | null
+  client_kind: ClientKind
+  client_session_id: string | null
+  cwd: string | null
   created_at: string    // ISO 8601 UTC
   last_activity: string // ISO 8601 UTC
-  released_at?: string | null // ISO 8601 UTC; NULL means active
+  last_seen_at: string | null // ISO 8601 UTC
+  released_at: string | null // ISO 8601 UTC; NULL means active
 }
 
 export interface MessageRow {
@@ -16,6 +20,7 @@ export interface MessageRow {
   sender_id: SessionId
   recipient_id: SessionId
   broadcast_id: string | null
+  reply_to: string | null
   content: string
   created_at: string   // ISO 8601 UTC
   read_at: string | null
@@ -33,6 +38,7 @@ export interface MessagePublic {
   id: string
   sender_id: SessionId
   sender_alias: string | null
+  reply_to: string | null
   content: string
   created_at: string   // ISO 8601 Asia/Taipei (API response)
   is_broadcast: boolean

--- a/types.ts
+++ b/types.ts
@@ -12,6 +12,7 @@ export interface SessionRow {
   created_at: string    // ISO 8601 UTC
   last_activity: string // ISO 8601 UTC
   last_seen_at: string | null // ISO 8601 UTC
+  generation: number
   released_at: string | null // ISO 8601 UTC; NULL means active
 }
 

--- a/types.ts
+++ b/types.ts
@@ -2,6 +2,7 @@
 
 export type SessionId = string  // UUID
 export type ClientKind = 'claude_code' | 'codex' | 'external'
+export type BroadcastScope = 'all' | 'same_kind' | 'same_cwd'
 
 export interface SessionRow {
   id: SessionId

--- a/waiters.ts
+++ b/waiters.ts
@@ -6,9 +6,11 @@
  *
  * Two things are tracked:
  *   1. per-session waiter callbacks (notify-on-new-message)
- *   2. the set of cc_session_ids currently inside /poll (liveness signal
- *      for delivered_notification — an alternative to reading state files)
+ *   2. kind-qualified client identities currently inside /poll (liveness
+ *      signal for online/delivery status)
  */
+
+import type { ClientKind } from './types'
 
 export interface Waiter {
   resolve: () => void
@@ -16,7 +18,11 @@ export interface Waiter {
 
 export class UnreadWaiterRegistry {
   private waiters = new Map<string, Set<Waiter>>()
-  private polling = new Set<string>()
+  private polling = new Map<string, number>()
+
+  private pollingKey(clientKind: ClientKind, clientSessionId: string): string {
+    return `${clientKind}:${clientSessionId}`
+  }
 
   /**
    * Wait until notify(sessionId) is called, the timer fires, or the caller
@@ -24,18 +30,21 @@ export class UnreadWaiterRegistry {
    * next by re-checking unread counts.
    *
    * @param sessionId switchboard session id to wait on
-   * @param ccSessionId cc_session_id of the caller (for the polling set)
+   * @param clientKind client namespace of the caller
+   * @param clientSessionId stable client identity of the caller
    * @param timeoutMs fallback timeout
    * @param abortSignal optional AbortSignal to break out early (e.g. when
    *        the HTTP client hangs up)
    */
   async wait(
     sessionId: string,
-    ccSessionId: string,
+    clientKind: ClientKind,
+    clientSessionId: string,
     timeoutMs: number,
     abortSignal?: AbortSignal,
   ): Promise<void> {
-    this.polling.add(ccSessionId)
+    const pollingKey = this.pollingKey(clientKind, clientSessionId)
+    this.polling.set(pollingKey, (this.polling.get(pollingKey) ?? 0) + 1)
     try {
       await new Promise<void>((resolve) => {
         const set = this.waiters.get(sessionId) ?? new Set<Waiter>()
@@ -67,7 +76,12 @@ export class UnreadWaiterRegistry {
         }
       })
     } finally {
-      this.polling.delete(ccSessionId)
+      const remaining = (this.polling.get(pollingKey) ?? 1) - 1
+      if (remaining > 0) {
+        this.polling.set(pollingKey, remaining)
+      } else {
+        this.polling.delete(pollingKey)
+      }
     }
   }
 
@@ -83,9 +97,9 @@ export class UnreadWaiterRegistry {
     for (const id of sessionIds) this.notify(id)
   }
 
-  /** True if a curl shim for this cc_session_id is currently long-polling. */
-  isPolling(ccSessionId: string): boolean {
-    return this.polling.has(ccSessionId)
+  /** True if this kind-qualified client identity is currently polling. */
+  isPolling(clientKind: ClientKind, clientSessionId: string): boolean {
+    return this.polling.has(this.pollingKey(clientKind, clientSessionId))
   }
 
   /**


### PR DESCRIPTION
## Motivation

Extend Switchboard from a Claude Code-only session router into a **bidirectional peer fabric**: Codex (and future non-MCP clients) become full peers with stable identities, honest online status, and scoped broadcast delivery — while every existing Claude Code path keeps working unchanged.

Design spec (finalized 2026-07-24 by 阿童/阿宇/小回, three-party review): `docs/superpowers/specs/2026-07-24-switchboard-bidirectional-peer-design.md`

## Five stages

1. **Schema migration** (`87eced6`) — `client_kind` namespace, `cc_session_id`→`client_session_id` rename, `cwd`, `last_seen_at`, `reply_to`; transactional in-place migration preserving all rows (verified against a copy of the live production DB).
2. **HTTP register/unregister** (`15abe60`) — `POST /register` idempotent upsert keyed on `(client_kind, client_session_id)` with a **generation** counter; `POST /unregister` requires a matching generation so a stale instance can never evict a live one. Runtime validation with 400/404/409 semantics. MCP register refactored onto the same helper (error strings and response shape unchanged).
3. **Lease-based presence** (`09a4d5e`, `707d6b7`) — canonical `/poll?client_kind&client_session_id` (legacy `cc_session_id` alias kept); every poll renews `last_seen_at`; shared predicate `online = live MCP connection OR active poll OR valid lease (TTL 5 min)`; `delivered_notification`/`notified_count` unified on it. Generation guard extended to **all** release paths — transport onclose and the explicit MCP `unregister` tool (the latter was a review-caught regression fixed in `707d6b7` with a dedicated race test).
4. **Scoped broadcast** (`657acbd`) — `broadcast(message, scope?)` with `all` (default) / `same_kind` / `same_cwd`; `same_cwd` requires both cwds non-NULL. Offline Codex peers are excluded **before** persistence — no mailbox backlog; Claude Code/external keep durable offline delivery. Counts derive from the filtered recipient set.
5. **Companion Codex waker** (codex-bridge `cad6583`) — generation-aware register, long-poll lease renewal decoupled from Codex turns, message-id dedup, new-thread/resume/permission-fallback wake policy, graceful unregister on SIGTERM, crash = lease expiry.

## Compatibility promises

- MCP `register(role, cc_session_id)` unchanged (same response shape, same error strings)
- Legacy `GET /poll?cc_session_id=...` fully supported
- `broadcast` without `scope` behaves exactly as before
- `POST /external/send` retained as legacy entry point
- Message truth remains `read_at`; wakes are best-effort doorbells

## Verification

- `bun test`: **149 pass / 0 fail** (353 assertions, 10 files) — includes migration-on-live-DB-copy, generation race regressions, scoped-broadcast matrix (3 scopes × codex online/offline), lease/online predicate suites
- `bunx tsc --noEmit`: clean
- codex-bridge waker: `unittest` 14/14 against fake Switchboard/app-server

## Known limitations

> Codex peers can register, renew leases, receive polling signals, and participate in scoped delivery. Switchboard does not yet expose a generation/identity-guarded HTTP endpoint for reading and marking peer messages as read. The companion Codex waker therefore degrades to a deduplicated limitation notification and does not access SQLite directly. Adding the HTTP peer message-read endpoint is tracked as follow-up work and does not block this PR.

- Crashed sessions that never fire `transport.onclose` can hold an alias for up to ~26 h (24 h stale threshold + 2 h sweep); same-identity re-register reclaims instantly. An offline-alias reclaim policy is a candidate follow-up.

## Security

Unchanged: loopback-only bind, no authentication — must never be exposed beyond 127.0.0.1.

## Process note

Implemented via three-party workflow: 小回 (Codex) wrote each stage test-first, 阿宇 (Claude Code) reviewed/committed, 小回 ran independent final checks per stage — including one review-caught blocker (stale-transport unregister race) fixed and re-verified before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJvBuVgYtpZmJbDpPshrLZ
