### PR TITLE
Peer message reads: generation-guarded HTTP inbox access

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ Codex-kind recipients are only written to when they are online at insert time �
   The generation must match the current row — a delayed unregister from an
   older instance cannot release a newer one (409). Returns
   `{status: "released" | "already_released"}`, 404 when unknown.
+- `POST /messages/read` — authenticated peer inbox read. JSON body:
+  `{ "client_kind": ..., "client_session_id": ..., "generation": <int> }`.
+  The identity must resolve to an active session and the generation must match.
+  Returns `{messages: [...]}` with the same fields and Asia/Taipei timestamps as
+  MCP `read_messages`, and marks the returned messages read.
+  Validation errors return 400, unknown or released identities return 404, and
+  stale generations return 409.
 - `GET /poll?client_kind=<kind>&client_session_id=<id>&timeout_s=<1..250>` —
   canonical long-poll for unread mail. Every call also renews the caller's
   lease (`last_seen_at`). The legacy form `?cc_session_id=<uuid>` remains
@@ -267,10 +274,10 @@ Sessions are generalized beyond Claude Code:
   Graceful exits unregister by generation; crashes simply let the lease
   expire. Message truth remains `read_at` — wakes are best-effort doorbells.
 
-**Known limitation (tracked follow-up):** Switchboard does not yet expose a
-generation/identity-guarded HTTP endpoint for peers to read and mark their
-messages. The companion Codex waker (codex-bridge) therefore degrades to a
-deduplicated unread notification and does not read SQLite directly.
+**Peer message reads:** `POST /messages/read` now gives non-MCP peers a
+generation/identity-guarded way to fetch and mark their own unread messages.
+It shares the MCP `read_messages` read-at semantics, so poll-driven clients can
+consume the inbox without touching SQLite or retriggering on already-read mail.
 
 ## Retention & cleanup
 
@@ -302,7 +309,7 @@ bunx tsc --noEmit        # type check
 
 ```
 main.ts                  # daemon entry
-server.ts                # MCP tool handlers + /register + /unregister + /poll + /monitor + Bun.serve wiring
+server.ts                # MCP tools + peer lifecycle/read + /poll + /monitor + Bun.serve wiring
 db.ts                    # SQLite helpers (sessions, messages, generation-aware upsert, retention queries)
 schema.sql               # DB schema (client_kind / client_session_id / cwd / last_seen_at / generation / reply_to)
 online.ts                # shared online predicate: MCP connection OR polling OR valid lease

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -180,6 +180,12 @@ Role 名字挑一個能描述這個 session 在做什麼的（例如 `tools`、`
   `{ "client_kind": ..., "client_session_id": ..., "generation": <int> }`。
   generation 必須與現值相符——舊 instance 遲到的下線請求動不了新 instance（409）。回傳
   `{status: "released" | "already_released"}`，查無此 identity 回 404。
+- `POST /messages/read` — peer 驗證身分後讀取自己的 inbox。JSON body：
+  `{ "client_kind": ..., "client_session_id": ..., "generation": <int> }`。
+  identity 必須對應 active session，generation 也必須與現值相符。回傳
+  `{messages: [...]}`，欄位與 Asia/Taipei 時間格式均和 MCP `read_messages` 相同，
+  並將本次回傳的訊息標為已讀。驗證錯誤回 400、查無或已釋放 identity 回 404、
+  舊 generation 回 409。
 - `GET /poll?client_kind=<kind>&client_session_id=<id>&timeout_s=<1..250>` —
   正式版 long-poll 等待新訊息，每次呼叫同時為呼叫者續租 lease（更新 `last_seen_at`）。
   舊格式 `?cc_session_id=<uuid>` 仍支援，等同 `client_kind=claude_code`。回 JSON：
@@ -255,9 +261,10 @@ session 已一般化，不再是 Claude Code 專屬：
   優雅退出走 generation unregister；crash 就讓 lease 自然過期。訊息的真相永遠是
   `read_at`——喚醒只是 best-effort 的門鈴。
 
-**已知限制（列管後續項目）**：Switchboard 尚未提供以 generation/identity 驗證身分的
-HTTP 讀信端點供 peer 讀取並標記自己的訊息。codex-bridge 的 Codex waker 因此降級為
-去重後的 unread 通知，且不直接讀 SQLite。
+**Peer 讀信已完成**：`POST /messages/read` 已提供非 MCP peer 以
+generation/identity 驗證身分、讀取並標記自己未讀訊息的途徑。它與 MCP
+`read_messages` 共用 read-at 語意，因此 poll 驅動的 client 不必直接讀 SQLite，
+也不會再被已讀郵件重複觸發。
 
 ## 保留 & 清理
 
@@ -286,7 +293,7 @@ bunx tsc --noEmit        # type check
 
 ```
 main.ts                  # daemon 入口
-server.ts                # MCP 工具 handler + /register + /unregister + /poll + /monitor + Bun.serve
+server.ts                # MCP 工具 + peer lifecycle/read + /poll + /monitor + Bun.serve
 db.ts                    # SQLite helper（session、訊息、generation-aware upsert、保留查詢）
 schema.sql               # schema（client_kind / client_session_id / cwd / last_seen_at / generation / reply_to）
 online.ts                # 共用 online 判定：MCP 連線 OR polling OR 有效 lease

--- a/docs/superpowers/specs/2026-07-24-switchboard-bidirectional-peer-design.md
+++ b/docs/superpowers/specs/2026-07-24-switchboard-bidirectional-peer-design.md
@@ -1,15 +1,16 @@
 # Switchboard 雙邊 Peer 化設計（Codex 完整入網）
 
 - 日期：2026-07-24
-- 狀態：**實作完成，待 PR 整體終檢**（同日五階段交付）
+- 狀態：**實作完成**（五階段交付＋HTTP peer message-read endpoint）
 - 參與：阿童（決策）、阿宇（Claude Code）、小回（Codex）
 - 討論紀錄：codex thread `019f926a-2c4e-78d2-be12-147118a942ab`（`codex resume` 可回看完整往返）
 - 實作 commits：`87eced6`（schema migration）→ `15abe60`（HTTP register/unregister）→
   `09a4d5e`＋`707d6b7`（lease、/poll 一般化、generation guard 全通路）→
   `657acbd`（broadcast scope）；waker 在 codex-bridge repo `cad6583`
-- 後續非阻擋項目：新增由 `client_kind + client_session_id + generation` 驗證身分的
-  HTTP peer message-read endpoint，回傳與 MCP `read_messages` 相同欄位並維持一致的
-  read-at 語意。Codex waker 已預留 full-message adapter；本次 PR 不包含此 endpoint。
+- 已實作 `POST /messages/read`：由
+  `client_kind + client_session_id + generation` 驗證 active session 身分，
+  回傳與 MCP `read_messages` 相同欄位並共用一致的 read-at 語意。
+  Codex waker 可透過既有 full-message adapter 接入，不需直接讀取 SQLite。
 
 ## 背景與目標
 

--- a/server.ts
+++ b/server.ts
@@ -136,6 +136,23 @@ export async function startServer(opts: {
     return requireJsonObject(parsed)
   }
 
+  function readUnreadMessages(sessionId: string) {
+    const unread = fetchUnreadForRecipient(db, sessionId)
+    markMessagesRead(db, unread.map(message => message.id))
+    return unread.map(message => {
+      const sender = findSessionById(db, message.sender_id)
+      return {
+        id: message.id,
+        sender_id: message.sender_id,
+        sender_alias: sender?.alias ?? null,
+        reply_to: message.reply_to,
+        content: message.content,
+        created_at: toTaipeiISOString(message.created_at),
+        is_broadcast: message.broadcast_id !== null,
+      }
+    })
+  }
+
   async function handleRegister(req: Request): Promise<Response> {
     if (req.method !== 'POST') {
       return new Response('Method Not Allowed', { status: 405 })
@@ -203,6 +220,43 @@ export async function startServer(opts: {
         )
       }
       return Response.json({ status: result })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (error instanceof RequestValidationError) {
+        return Response.json({ error: message }, { status: 400 })
+      }
+      return Response.json({ error: 'internal server error' }, { status: 500 })
+    }
+  }
+
+  async function handleMessageRead(req: Request): Promise<Response> {
+    if (req.method !== 'POST') {
+      return new Response('Method Not Allowed', { status: 405 })
+    }
+
+    try {
+      const body = await parseJsonBody(req)
+      const client_kind = requireClientKind(body)
+      const client_session_id = requireNonEmptyString(body, 'client_session_id')
+      const generation = requireGeneration(body)
+      const session = findSessionByClientSessionId(
+        db,
+        client_kind,
+        client_session_id,
+      )
+
+      if (!session) {
+        return Response.json({ error: 'session not found' }, { status: 404 })
+      }
+      if (session.generation !== generation) {
+        return Response.json(
+          {
+            error: `generation mismatch: current generation is ${session.generation}`,
+          },
+          { status: 409 },
+        )
+      }
+      return Response.json({ messages: readUnreadMessages(session.id) })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       if (error instanceof RequestValidationError) {
@@ -598,22 +652,13 @@ export async function startServer(opts: {
 
       if (name === 'read_messages') {
         if (!currentSwitchboardId) throw new Error('session not registered; call register() first')
-        const unread = fetchUnreadForRecipient(db, currentSwitchboardId)
-        markMessagesRead(db, unread.map(m => m.id))
-        const messages = unread.map(m => {
-          const senderRow = findSessionById(db, m.sender_id)
-          return {
-            id: m.id,
-            sender_id: m.sender_id,
-            sender_alias: senderRow?.alias ?? null,
-            reply_to: m.reply_to,
-            content: m.content,
-            created_at: toTaipeiISOString(m.created_at),
-            is_broadcast: m.broadcast_id !== null,
-          }
-        })
         return {
-          content: [{ type: 'text', text: JSON.stringify({ messages }) }],
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              messages: readUnreadMessages(currentSwitchboardId),
+            }),
+          }],
         }
       }
 
@@ -935,6 +980,10 @@ export async function startServer(opts: {
 
       if (url.pathname === '/unregister') {
         return handleUnregister(req)
+      }
+
+      if (url.pathname === '/messages/read') {
+        return handleMessageRead(req)
       }
 
       if (url.pathname !== '/mcp') {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1047,6 +1047,7 @@ test('/monitor abort releases the waiter so cancelAll isn\'t stuck on shutdown',
 const EXTERNAL_SEND_URL = `http://127.0.0.1:${TEST_PORT}/external/send`
 const REGISTER_URL = `http://127.0.0.1:${TEST_PORT}/register`
 const UNREGISTER_URL = `http://127.0.0.1:${TEST_PORT}/unregister`
+const MESSAGE_READ_URL = `http://127.0.0.1:${TEST_PORT}/messages/read`
 
 test('/external/send delivers and wakes a registered Claude Code session', async () => {
   const recipient = await makeClient('external-recip')
@@ -1267,4 +1268,201 @@ test('HTTP unregister validates identity and generation fields', async () => {
     expect(resp.status).toBe(400)
     expect(await resp.json()).toEqual({ error: invalidCase.error })
   }
+})
+
+test('HTTP message read validates identity and generation fields', async () => {
+  const invalidCases: Array<{ body: unknown; error: string }> = [
+    {
+      body: { client_kind: 'other', client_session_id: 'thread', generation: 1 },
+      error: 'client_kind must be one of: claude_code, codex, external',
+    },
+    {
+      body: { client_kind: 'codex', client_session_id: '', generation: 1 },
+      error: 'client_session_id is required and must be a non-empty string',
+    },
+    {
+      body: { client_kind: 'codex', client_session_id: 'thread', generation: 0 },
+      error: 'generation is required and must be a positive integer',
+    },
+  ]
+
+  for (const invalidCase of invalidCases) {
+    const resp = await postJson(MESSAGE_READ_URL, invalidCase.body)
+    expect(resp.status).toBe(400)
+    expect(await resp.json()).toEqual({ error: invalidCase.error })
+  }
+})
+
+test('HTTP message read returns 404 for an unknown or released identity', async () => {
+  const unknownResp = await postJson(MESSAGE_READ_URL, {
+    client_kind: 'codex',
+    client_session_id: 'missing-reader',
+    generation: 1,
+  })
+  expect(unknownResp.status).toBe(404)
+  expect(await unknownResp.json()).toEqual({ error: 'session not found' })
+
+  const registered = await (await postJson(REGISTER_URL, {
+    alias: 'released-reader',
+    client_kind: 'codex',
+    client_session_id: 'released-reader',
+    cwd: '/workspace',
+  })).json()
+  await postJson(UNREGISTER_URL, {
+    client_kind: 'codex',
+    client_session_id: 'released-reader',
+    generation: registered.generation,
+  })
+
+  const releasedResp = await postJson(MESSAGE_READ_URL, {
+    client_kind: 'codex',
+    client_session_id: 'released-reader',
+    generation: registered.generation,
+  })
+  expect(releasedResp.status).toBe(404)
+  expect(await releasedResp.json()).toEqual({ error: 'session not found' })
+})
+
+test('HTTP message read rejects a stale generation', async () => {
+  const first = await (await postJson(REGISTER_URL, {
+    alias: 'http-reader-old',
+    client_kind: 'codex',
+    client_session_id: 'http-reader-generation',
+    cwd: '/workspace',
+  })).json()
+  const current = await (await postJson(REGISTER_URL, {
+    alias: 'http-reader-current',
+    client_kind: 'codex',
+    client_session_id: 'http-reader-generation',
+    cwd: '/workspace',
+  })).json()
+
+  const resp = await postJson(MESSAGE_READ_URL, {
+    client_kind: 'codex',
+    client_session_id: 'http-reader-generation',
+    generation: first.generation,
+  })
+  expect(resp.status).toBe(409)
+  expect(await resp.json()).toEqual({
+    error: `generation mismatch: current generation is ${current.generation}`,
+  })
+})
+
+test('HTTP message read returns unread messages and clears subsequent poll state', async () => {
+  const peer = await (await postJson(REGISTER_URL, {
+    alias: 'http-reader',
+    client_kind: 'codex',
+    client_session_id: 'http-reader-instance',
+    cwd: '/workspace',
+  })).json()
+  const sender = await makeClient('http-read-sender')
+  await sender.callTool({ name: 'register', arguments: { role: 'http-read-sender' } })
+  const sendResult = await sender.callTool({
+    name: 'send',
+    arguments: { to: 'http-reader', message: 'read me over HTTP' },
+  })
+  const sent = JSON.parse((sendResult.content as any[])[0].text)
+
+  const unreadPoll = await fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=http-reader-instance&timeout_s=1`,
+  )
+  expect(await unreadPoll.json()).toMatchObject({ status: 'unread', count: 1 })
+
+  const readResp = await postJson(MESSAGE_READ_URL, {
+    client_kind: 'codex',
+    client_session_id: 'http-reader-instance',
+    generation: peer.generation,
+  })
+  expect(readResp.status).toBe(200)
+  expect(await readResp.json()).toEqual({
+    messages: [{
+      id: sent.message_id,
+      sender_id: expect.any(String),
+      sender_alias: 'http-read-sender',
+      reply_to: null,
+      content: 'read me over HTTP',
+      created_at: expect.stringMatching(/\+08:00$/),
+      is_broadcast: false,
+    }],
+  })
+
+  const clearedPoll = await fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=http-reader-instance&timeout_s=1`,
+  )
+  expect(await clearedPoll.json()).toEqual({ status: 'timeout' })
+  await sender.close()
+})
+
+test('HTTP and MCP message reads share read state without duplicate delivery', async () => {
+  await postJson(REGISTER_URL, {
+    alias: 'mixed-reader',
+    client_kind: 'claude_code',
+    client_session_id: 'mixed-reader-session',
+    cwd: '/workspace',
+  })
+  const recipient = await makeClient('mixed-read-recipient')
+  await recipient.callTool({
+    name: 'register',
+    arguments: { role: 'mixed-reader', cc_session_id: 'mixed-reader-session' },
+  })
+  const current = await (await postJson(REGISTER_URL, {
+    alias: 'mixed-reader',
+    client_kind: 'claude_code',
+    client_session_id: 'mixed-reader-session',
+    cwd: '/workspace',
+  })).json()
+  const sender = await makeClient('mixed-read-sender')
+  await sender.callTool({ name: 'register', arguments: { role: 'mixed-read-sender' } })
+
+  await sender.callTool({
+    name: 'send',
+    arguments: { to: 'mixed-reader', message: 'HTTP gets this one' },
+  })
+  const httpFirst = await postJson(MESSAGE_READ_URL, {
+    client_kind: 'claude_code',
+    client_session_id: 'mixed-reader-session',
+    generation: current.generation,
+  })
+  expect((await httpFirst.json()).messages.map((message: any) => message.content))
+    .toEqual(['HTTP gets this one'])
+  const mcpAfterHttp = JSON.parse(((
+    await recipient.callTool({ name: 'read_messages', arguments: {} })
+  ).content as any[])[0].text)
+  expect(mcpAfterHttp).toEqual({ messages: [] })
+
+  await sender.callTool({
+    name: 'send',
+    arguments: { to: 'mixed-reader', message: 'MCP gets this one' },
+  })
+  const mcpFirst = JSON.parse(((
+    await recipient.callTool({ name: 'read_messages', arguments: {} })
+  ).content as any[])[0].text)
+  expect(mcpFirst.messages.map((message: any) => message.content))
+    .toEqual(['MCP gets this one'])
+  const httpAfterMcp = await postJson(MESSAGE_READ_URL, {
+    client_kind: 'claude_code',
+    client_session_id: 'mixed-reader-session',
+    generation: current.generation,
+  })
+  expect(await httpAfterMcp.json()).toEqual({ messages: [] })
+
+  await sender.close()
+  await recipient.close()
+})
+
+test('HTTP message read returns an empty array for an empty mailbox', async () => {
+  const peer = await (await postJson(REGISTER_URL, {
+    alias: 'empty-http-reader',
+    client_kind: 'external',
+    client_session_id: 'empty-http-reader',
+    cwd: '/workspace',
+  })).json()
+
+  const resp = await postJson(MESSAGE_READ_URL, {
+    client_kind: 'external',
+    client_session_id: 'empty-http-reader',
+    generation: peer.generation,
+  })
+  expect(resp.status).toBe(200)
+  expect(await resp.json()).toEqual({ messages: [] })
 })


### PR DESCRIPTION
## Motivation

Completes the known limitation from #1: peers registered over HTTP (Codex waker / OpenCode plugin) could receive unread signals but had no way to read message bodies — which in practice caused a poll→wake notification loop (2026-07-29, mitigated client-side by throttling). This PR closes the loop.

## Changes

- `POST /messages/read` — body `{client_kind, client_session_id, generation}`; active-identity + generation strictly verified (400/404/409/500 semantics aligned with `/unregister`)
- Shares unread fetch / mark-read / Asia-Taipei formatting with MCP `read_messages` — no duplicated queries, identical field shapes
- README (en/zh-TW) endpoint docs updated; known-limitation paragraphs resolved; design spec annotated as implemented

## Verification

- `bun test`: 155 pass / 0 fail (375 assertions) — identity failures, unread-clears-poll, MCP interop, empty inbox
- `bunx tsc --noEmit`: clean

## Process

小回 (Codex) implemented test-first per the spec note he authored in #1; 阿宇 reviewed and committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJvBuVgYtpZmJbDpPshrLZ