### PR TITLE
Unified peer identity: MCP connections can claim doorbell extensions

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -333,6 +333,7 @@ export async function startServer(opts: {
     let currentSwitchboardId: string | null = null
     let currentGeneration: number | null = null
     let currentPushCallback: PushCallback | null = null
+    let currentOwnsLifecycle = true
 
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: () => crypto.randomUUID(),
@@ -353,7 +354,7 @@ export async function startServer(opts: {
         if (currentPushCallback) {
           registry.unregister(currentSwitchboardId, currentPushCallback)
         }
-        if (currentGeneration !== null) {
+        if (currentOwnsLifecycle && currentGeneration !== null) {
           releaseSessionIfGeneration(db, currentSwitchboardId, currentGeneration)
         }
       }
@@ -386,6 +387,15 @@ export async function startServer(opts: {
               cc_session_id: {
                 type: 'string',
                 description: 'Optional Claude Code session id (from hook additionalContext). When provided, register becomes idempotent: same cc_session_id returns / updates the same switchboard session row.',
+              },
+              client_kind: {
+                type: 'string',
+                enum: CLIENT_KINDS,
+                description: 'Optional peer client kind to claim an existing HTTP-registered peer row. Must be supplied with client_session_id.',
+              },
+              client_session_id: {
+                type: 'string',
+                description: 'Optional peer client session id to claim an existing HTTP-registered peer row. Must be supplied with client_kind.',
               },
             },
             required: [],
@@ -476,11 +486,39 @@ export async function startServer(opts: {
         const argsObj = (args as Record<string, unknown>) ?? {}
         const role = (argsObj.role as string | undefined) ?? null
         const cc_session_id = (argsObj.cc_session_id as string | undefined) ?? null
+        const clientKindArg = argsObj.client_kind
+        const clientSessionIdArg = argsObj.client_session_id
 
         let sessionId: string
         let generation: number
+        let ownsLifecycle = true
 
-        if (cc_session_id) {
+        if (clientKindArg !== undefined || clientSessionIdArg !== undefined) {
+          if (cc_session_id) {
+            throw new Error('use either cc_session_id or client_kind + client_session_id')
+          }
+          if (typeof clientKindArg !== 'string' || !CLIENT_KINDS.includes(clientKindArg as ClientKind)) {
+            throw new Error(`client_kind must be one of: ${CLIENT_KINDS.join(', ')}`)
+          }
+          if (typeof clientSessionIdArg !== 'string' || clientSessionIdArg.trim() === '') {
+            throw new Error('client_session_id is required and must be a non-empty string')
+          }
+          const claimed = findSessionByClientSessionId(
+            db,
+            clientKindArg as ClientKind,
+            clientSessionIdArg.trim(),
+          )
+          if (!claimed) {
+            throw new Error('session not found for client identity')
+          }
+          if (role !== null && role !== claimed.alias) {
+            throw new Error(`alias mismatch for claimed session: ${claimed.alias ?? '(anonymous)'}`)
+          }
+          sessionId = claimed.id
+          generation = claimed.generation
+          ownsLifecycle = false
+          updateLastActivity(db, sessionId)
+        } else if (cc_session_id) {
           // Durable Claude Code identities share the same generation-aware
           // upsert semantics as HTTP peers. The MCP response shape remains
           // unchanged for backward compatibility.
@@ -505,6 +543,7 @@ export async function startServer(opts: {
 
         currentSwitchboardId = sessionId
         currentGeneration = generation
+        currentOwnsLifecycle = ownsLifecycle
         if (transport.sessionId) {
           mcpSessionToSwitchboard.set(transport.sessionId, sessionId)
         }
@@ -699,20 +738,24 @@ export async function startServer(opts: {
         }
         const priorAlias = findSessionById(db, currentSwitchboardId)?.alias ?? null
         const released =
+          currentOwnsLifecycle &&
           currentGeneration !== null &&
           releaseSessionIfGeneration(db, currentSwitchboardId, currentGeneration)
+        const status = currentOwnsLifecycle
+          ? (released ? 'released' : 'stale_ignored')
+          : 'unbound'
         currentSwitchboardId = null
         currentGeneration = null
         currentPushCallback = null
+        currentOwnsLifecycle = true
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify(
-                released
-                  ? { status: 'released', released_alias: priorAlias }
-                  : { status: 'stale_ignored', released_alias: null },
-              ),
+              text: JSON.stringify({
+                status,
+                released_alias: released ? priorAlias : null,
+              }),
             },
           ],
         }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -477,6 +477,159 @@ test('register without cc_session_id still creates a new session each time (Phas
   await c2.close()
 })
 
+test('register(client_kind, client_session_id) claims an active peer without bumping generation', async () => {
+  const peerResp = await postJson(REGISTER_URL, {
+    alias: 'claim-codex-peer',
+    client_kind: 'codex',
+    client_session_id: 'claim-codex-session',
+    cwd: '/workspace/codex',
+  })
+  expect(peerResp.status).toBe(200)
+  const peer = await peerResp.json()
+  expect(peer.generation).toBe(1)
+
+  const claimant = await makeClient('claim-codex-mcp')
+  const claimed = JSON.parse(((await claimant.callTool({
+    name: 'register',
+    arguments: {
+      client_kind: 'codex',
+      client_session_id: 'claim-codex-session',
+    },
+  })).content as any[])[0].text)
+  expect(claimed).toMatchObject({
+    session_id: peer.session_id,
+    alias: 'claim-codex-peer',
+    anonymous: false,
+  })
+
+  const readResp = await postJson(MESSAGE_READ_URL, {
+    client_kind: 'codex',
+    client_session_id: 'claim-codex-session',
+    generation: peer.generation,
+  })
+  expect(readResp.status).toBe(200)
+
+  await claimant.close()
+})
+
+test('claimed peer sends with peer alias and receives through the claimed MCP transport', async () => {
+  await postJson(REGISTER_URL, {
+    alias: 'claimed-recipient-peer',
+    client_kind: 'codex',
+    client_session_id: 'claimed-recipient-session',
+    cwd: '/workspace/codex',
+  })
+
+  const claimedRecipient = await makeClient('claimed-recipient-mcp')
+  await claimedRecipient.callTool({
+    name: 'register',
+    arguments: {
+      client_kind: 'codex',
+      client_session_id: 'claimed-recipient-session',
+    },
+  })
+  const sender = await makeClient('claimed-sender-mcp')
+  await sender.callTool({ name: 'register', arguments: { role: 'claimed-sender' } })
+
+  const sendToClaimed = JSON.parse(((await sender.callTool({
+    name: 'send',
+    arguments: { to: 'claimed-recipient-peer', message: 'hello claimed peer' },
+  })).content as any[])[0].text)
+  expect(sendToClaimed.delivered_notification).toBe(true)
+
+  const readClaimed = JSON.parse(((await claimedRecipient.callTool({
+    name: 'read_messages',
+    arguments: {},
+  })).content as any[])[0].text)
+  expect(readClaimed.messages).toHaveLength(1)
+  expect(readClaimed.messages[0].content).toBe('hello claimed peer')
+  expect(readClaimed.messages[0].sender_alias).toBe('claimed-sender')
+
+  const claimedSend = await claimedRecipient.callTool({
+    name: 'send',
+    arguments: { to: 'claimed-sender', message: 'from peer alias' },
+  })
+  expect(JSON.parse((claimedSend.content as any[])[0].text).delivered_notification).toBe(true)
+  const senderRead = JSON.parse(((await sender.callTool({
+    name: 'read_messages',
+    arguments: {},
+  })).content as any[])[0].text)
+  expect(senderRead.messages[0].sender_alias).toBe('claimed-recipient-peer')
+
+  await sender.close()
+  await claimedRecipient.close()
+})
+
+test('closing or unregistering a claimed peer MCP transport keeps the plugin-owned peer row active', async () => {
+  const peer = await (await postJson(REGISTER_URL, {
+    alias: 'claim-lifecycle-peer',
+    client_kind: 'codex',
+    client_session_id: 'claim-lifecycle-session',
+    cwd: '/workspace/codex',
+  })).json()
+
+  const closer = await makeClient('claim-lifecycle-close')
+  await closer.callTool({
+    name: 'register',
+    arguments: {
+      client_kind: 'codex',
+      client_session_id: 'claim-lifecycle-session',
+    },
+  })
+  await closer.close()
+  await new Promise((r) => setTimeout(r, 50))
+
+  const stillReadable = await postJson(MESSAGE_READ_URL, {
+    client_kind: 'codex',
+    client_session_id: 'claim-lifecycle-session',
+    generation: peer.generation,
+  })
+  expect(stillReadable.status).toBe(200)
+
+  const unregistering = await makeClient('claim-lifecycle-unregister')
+  await unregistering.callTool({
+    name: 'register',
+    arguments: {
+      client_kind: 'codex',
+      client_session_id: 'claim-lifecycle-session',
+    },
+  })
+  const unregistered = JSON.parse(((await unregistering.callTool({
+    name: 'unregister',
+    arguments: {},
+  })).content as any[])[0].text)
+  expect(unregistered).toEqual({ status: 'unbound', released_alias: null })
+
+  const releaseResp = await postJson(UNREGISTER_URL, {
+    client_kind: 'codex',
+    client_session_id: 'claim-lifecycle-session',
+    generation: peer.generation,
+  })
+  expect(releaseResp.status).toBe(200)
+  expect(await releaseResp.json()).toEqual({ status: 'released' })
+  await unregistering.close()
+})
+
+test('register(client_kind, client_session_id, role) rejects mismatched peer alias', async () => {
+  await postJson(REGISTER_URL, {
+    alias: 'claim-conflict-peer',
+    client_kind: 'codex',
+    client_session_id: 'claim-conflict-session',
+    cwd: '/workspace/codex',
+  })
+
+  const claimant = await makeClient('claim-conflict-mcp')
+  await expect(claimant.callTool({
+    name: 'register',
+    arguments: {
+      role: 'different-alias',
+      client_kind: 'codex',
+      client_session_id: 'claim-conflict-session',
+    },
+  })).rejects.toThrow()
+  await claimant.close()
+})
+
 // --- /poll long-polling endpoint ---
 
 const POLL_URL = `http://127.0.0.1:${TEST_PORT}/poll`


### PR DESCRIPTION
## Motivation

Closes #4. An OpenCode session previously had two switchboard identities: the plugin-registered doorbell extension (reachable, named after the session title) and its own MCP registration (the only way to send, but bell-less and unrelated in name). Replies came back under a different name than the one you dialed — and the dispatch for this very issue got lost in a bell-less mailbox, twice proving the point.

## Design (方案 1: claim = bind, no generation bump)

- MCP `register` gains optional `client_kind` + `client_session_id`: the connection claims an existing active peer row.
- A claiming transport owns only its push callback, never the row's lifecycle: `transport.onclose` unbinds the callback only; MCP `unregister` on a claimed row returns `{status: 'unbound'}` and releases nothing. The plugin's generation-guarded poll/read/unregister continue untouched.
- `role`, if supplied, must equal the claimed row's alias — a TUI cannot rename the plugin's doorbell through claiming.
- Claiming a non-existent identity fails explicitly; this is claim-only, not an alternative peer-creation path.
- Legacy paths (`cc_session_id`, Phase 1 anonymous) byte-for-byte unchanged.

## Verification

- `bun test`: 159 pass / 0 fail (390 assertions) — claim happy path, no-bump, alias mismatch, disconnect/unregister non-release, legacy regression
- `bunx tsc --noEmit`: clean
- Live end-to-end on this machine: dialed `小回-門牌修正-vjp7S1ph`, the woken session claimed itself per the wake-prompt instructions, and replied **under the same name**. 收發同名 achieved.

## Companion change (not in this repo)

The OpenCode plugin's wake prompt now includes claim instructions (live file `~/.opencode/plugins/switchboard.ts`, backed up pre-change).

## Process

小回 implemented in-TUI with 阿童 approving live; 阿宇 reviewed (zero rewrites) and deployed for the live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJvBuVgYtpZmJbDpPshrLZ