### PR TITLE
Server 端 ownership CAS（#7 第一階段）

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,22 +181,36 @@ Codex-kind recipients are only written to when they are online at insert time �
   reactivates the row and bumps its generation. Returns
   `{session_id, alias, generation}`; 400 on validation errors, 409 on alias
   collision.
+  Optional `owner_token` opts into ownership CAS: acquiring an ownerless
+  identity or taking over an expired owner lease bumps the generation, a
+  same-owner call is a lease renewal that keeps its generation, and a second
+  owner is rejected with `409 {code: "owner_conflict"}` while the current
+  owner's lease is alive. Token-less registers keep last-register-wins
+  semantics and clear any stored owner token.
 - `POST /unregister` — graceful peer sign-off. JSON body:
   `{ "client_kind": ..., "client_session_id": ..., "generation": <int> }`.
   The generation must match the current row — a delayed unregister from an
   older instance cannot release a newer one (409). Returns
-  `{status: "released" | "already_released"}`, 404 when unknown.
+  `{status: "released" | "already_released"}`, 404 when unknown. With an
+  `owner_token`, 409 bodies carry `code: "stale_generation"` or
+  `code: "owner_mismatch"` so clients can tell the two apart.
 - `POST /messages/read` — authenticated peer inbox read. JSON body:
   `{ "client_kind": ..., "client_session_id": ..., "generation": <int> }`.
   The identity must resolve to an active session and the generation must match.
   Returns `{messages: [...]}` with the same fields and Asia/Taipei timestamps as
   MCP `read_messages`, and marks the returned messages read.
   Validation errors return 400, unknown or released identities return 404, and
-  stale generations return 409.
+  stale generations return 409. With an `owner_token`, 409 bodies carry
+  `code: "stale_generation"` or `code: "owner_mismatch"` — clients must treat
+  these as "stop waking", never as "endpoint unavailable".
 - `GET /poll?client_kind=<kind>&client_session_id=<id>&timeout_s=<1..250>` —
   canonical long-poll for unread mail. Every call also renews the caller's
   lease (`last_seen_at`). The legacy form `?cc_session_id=<uuid>` remains
-  supported as an alias for `client_kind=claude_code`. Returns JSON:
+  supported as an alias for `client_kind=claude_code`. Optional
+  `&owner_token=<t>&generation=<g>` (must appear together) makes the poll
+  owner-aware: mismatches return the same 409 bodies as `/messages/read`,
+  ownership is re-checked after the long wait, and the owner lease
+  (`owner_seen_at`) is renewed alongside the poll lease. Returns JSON:
   - `{status: "unread", count, alias, message}` — Stop-hook shim exits 2
   - `{status: "timeout"}` — shim re-dials
   - `{status: "no-session"}` — alias is gone; shim exits 0

--- a/README.md
+++ b/README.md
@@ -278,7 +278,10 @@ Sessions are generalized beyond Claude Code:
   durable instance UUID (for the Codex waker it persists in
   `~/.codex/waker-instance-id`). Conversation thread ids are client-side state
   and never enter the database.
-- **Generation guard.** Every re-register bumps the row's generation. All
+- **Generation guard.** Acquiring an identity bumps the row's generation —
+  legacy re-registers, first ownership grabs, and expired-lease takeovers all
+  count; the one exception is a same-`owner_token` renewal, which keeps its
+  generation. All
   release paths — HTTP `/unregister`, the MCP `unregister` tool, and MCP
   transport cleanup on disconnect — are generation-checked, so a stale
   instance's late sign-off can never evict the live one.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -265,7 +265,9 @@ session 已一般化，不再是 Claude Code 專屬：
   `(client_kind, client_session_id)`，Codex 的 instance id 永遠不會跟 Claude Code 的 session id 撞衫。
 - **穩定 identity，不是 thread identity**。peer 的 `client_session_id` 是持久的 instance UUID
   （Codex waker 存在 `~/.codex/waker-instance-id`）；對話 thread id 屬 client 端狀態，絕不進資料庫。
-- **generation guard**：每次重新註冊遞增 generation。所有釋放路徑——HTTP `/unregister`、
+- **generation guard**：取得 identity 時遞增 generation——legacy 重新註冊、首次取得
+  ownership、接手過期 lease 都算；唯一例外是同 `owner_token` 的續租，generation 不動。
+  所有釋放路徑——HTTP `/unregister`、
   MCP `unregister` 工具、MCP transport 斷線清理——都檢查 generation，舊 instance 遲到的
   下線動作不可能誤殺活著的新 instance。
 - **lease 制 online**：`online = 活的 MCP 連線 OR 進行中的 /poll(/monitor) OR 有效 lease`。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -176,19 +176,31 @@ Role 名字挑一個能描述這個 session 在做什麼的（例如 `tools`、`
   `{ "alias": "...", "client_kind": "claude_code"|"codex"|"external", "client_session_id": "<穩定的 instance id>", "cwd": "/絕對路徑" }`。
   以 `(client_kind, client_session_id)` 冪等 upsert；重複註冊會重新啟用該列並遞增 generation。回傳
   `{session_id, alias, generation}`；驗證錯誤回 400、alias 衝突回 409。
+  選填 `owner_token` 啟用 ownership CAS：取得無主 identity 或接手 lease 已過期的
+  舊 owner 會遞增 generation；同 owner 重呼叫視為 lease 續租、generation 不動；
+  現任 owner 的 lease 還活著時，第二個 owner 會被 `409 {code: "owner_conflict"}`
+  拒絕。不帶 token 的註冊維持 last-register-wins 語意，並會清掉已存的 owner token。
 - `POST /unregister` — peer 優雅下線。JSON body：
   `{ "client_kind": ..., "client_session_id": ..., "generation": <int> }`。
   generation 必須與現值相符——舊 instance 遲到的下線請求動不了新 instance（409）。回傳
-  `{status: "released" | "already_released"}`，查無此 identity 回 404。
+  `{status: "released" | "already_released"}`，查無此 identity 回 404。帶 `owner_token`
+  時，409 body 會標明 `code: "stale_generation"` 或 `code: "owner_mismatch"`，讓 client
+  能區分兩種失敗。
 - `POST /messages/read` — peer 驗證身分後讀取自己的 inbox。JSON body：
   `{ "client_kind": ..., "client_session_id": ..., "generation": <int> }`。
   identity 必須對應 active session，generation 也必須與現值相符。回傳
   `{messages: [...]}`，欄位與 Asia/Taipei 時間格式均和 MCP `read_messages` 相同，
   並將本次回傳的訊息標為已讀。驗證錯誤回 400、查無或已釋放 identity 回 404、
-  舊 generation 回 409。
+  舊 generation 回 409。帶 `owner_token` 時，409 body 會標明 `code: "stale_generation"`
+  或 `code: "owner_mismatch"`——client 收到這兩種要當「停止喚醒」處理，
+  絕不能當成「端點不可用」降級。
 - `GET /poll?client_kind=<kind>&client_session_id=<id>&timeout_s=<1..250>` —
   正式版 long-poll 等待新訊息，每次呼叫同時為呼叫者續租 lease（更新 `last_seen_at`）。
-  舊格式 `?cc_session_id=<uuid>` 仍支援，等同 `client_kind=claude_code`。回 JSON：
+  舊格式 `?cc_session_id=<uuid>` 仍支援，等同 `client_kind=claude_code`。可選
+  `&owner_token=<t>&generation=<g>`（兩者必須成對出現）讓 poll 帶 ownership 檢查：
+  不符時回與 `/messages/read` 相同的 409 body；long-poll 等待結束後會重查 ownership，
+  避免舊 owner 的長連線在新 owner 接手後還被喚醒；owner lease（`owner_seen_at`）
+  也隨 poll lease 一併續租。回 JSON：
   - `{status: "unread", count, alias, message}` — Stop-hook shim 應 `exit 2`
   - `{status: "timeout"}` — shim 重新撥接
   - `{status: "no-session"}` — alias 消失；shim `exit 0`

--- a/db.ts
+++ b/db.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url'
 import { randomUUID } from 'crypto'
 import type { ClientKind, SessionRow, MessageRow } from './types'
 import { nowUtc } from './time'
+import { LEASE_TTL_MS } from './online'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -51,6 +52,12 @@ function migrateSchema(db: Database): void {
     }
     if (!sessionColumns.has('generation')) {
       db.exec('ALTER TABLE sessions ADD COLUMN generation INTEGER NOT NULL DEFAULT 1')
+    }
+    if (!sessionColumns.has('owner_token')) {
+      db.exec('ALTER TABLE sessions ADD COLUMN owner_token TEXT')
+    }
+    if (!sessionColumns.has('owner_seen_at')) {
+      db.exec('ALTER TABLE sessions ADD COLUMN owner_seen_at TEXT')
     }
     if (!sessionColumns.has('released_at')) {
       db.exec('ALTER TABLE sessions ADD COLUMN released_at TEXT')
@@ -102,6 +109,7 @@ export function createClientSession(
     client_kind: ClientKind
     client_session_id?: string | null
     cwd?: string | null
+    owner_token?: string | null
   },
 ): string {
   const id = randomUUID()
@@ -109,9 +117,9 @@ export function createClientSession(
   db.query(`
     INSERT INTO sessions (
       id, alias, client_kind, client_session_id, cwd,
-      created_at, last_activity, last_seen_at, generation, released_at
+      created_at, last_activity, last_seen_at, generation, owner_token, owner_seen_at, released_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, NULL, 1, NULL)
+    VALUES (?, ?, ?, ?, ?, ?, ?, NULL, 1, ?, ?, NULL)
   `).run(
     id,
     opts.alias,
@@ -120,6 +128,8 @@ export function createClientSession(
     opts.cwd ?? null,
     now,
     now,
+    opts.owner_token ?? null,
+    opts.owner_token ? now : null,
   )
   return id
 }
@@ -127,7 +137,7 @@ export function createClientSession(
 export function findSessionById(db: Database, id: string): SessionRow | null {
   const row = db.query<SessionRow, [string]>(
     `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
-            last_activity, last_seen_at, generation, released_at
+            last_activity, last_seen_at, generation, owner_token, owner_seen_at, released_at
      FROM sessions
      WHERE id = ?`,
   ).get(id)
@@ -137,7 +147,7 @@ export function findSessionById(db: Database, id: string): SessionRow | null {
 export function findSessionByAlias(db: Database, alias: string): SessionRow | null {
   const row = db.query<SessionRow, [string]>(
     `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
-            last_activity, last_seen_at, generation, released_at
+            last_activity, last_seen_at, generation, owner_token, owner_seen_at, released_at
      FROM sessions
      WHERE alias = ? AND released_at IS NULL`,
   ).get(alias)
@@ -151,7 +161,7 @@ export function findSessionByClientSessionId(
 ): SessionRow | null {
   const row = db.query<SessionRow, [ClientKind, string]>(
     `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
-            last_activity, last_seen_at, generation, released_at
+            last_activity, last_seen_at, generation, owner_token, owner_seen_at, released_at
      FROM sessions
      WHERE client_kind = ? AND client_session_id = ? AND released_at IS NULL`,
   ).get(client_kind, client_session_id)
@@ -176,7 +186,7 @@ export function findAnySessionByClientSessionId(
 ): SessionRow | null {
   const row = db.query<SessionRow, [ClientKind, string]>(
     `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
-            last_activity, last_seen_at, generation, released_at
+            last_activity, last_seen_at, generation, owner_token, owner_seen_at, released_at
      FROM sessions
      WHERE client_kind = ? AND client_session_id = ?
      ORDER BY (released_at IS NULL) DESC, generation DESC, created_at DESC
@@ -197,6 +207,24 @@ export interface RegisterClientSessionInput {
   client_kind: ClientKind
   client_session_id: string
   cwd?: string | null
+  owner_token?: string
+}
+
+export class OwnershipConflictError extends Error {
+  constructor(readonly currentGeneration: number) {
+    super('session ownership is held by an active client')
+    this.name = 'OwnershipConflictError'
+  }
+}
+
+function hasValidOwnerLease(
+  session: SessionRow,
+  ownerLeaseTtlMs: number,
+): boolean {
+  if (session.released_at !== null || session.owner_token === null) return false
+  if (!session.owner_seen_at) return false
+  const lastSeenMs = Date.parse(session.owner_seen_at)
+  return Number.isFinite(lastSeenMs) && Date.now() - lastSeenMs < ownerLeaseTtlMs
 }
 
 /**
@@ -207,6 +235,7 @@ export interface RegisterClientSessionInput {
 export function registerClientSession(
   db: Database,
   input: RegisterClientSessionInput,
+  options: { ownerLeaseTtlMs?: number } = {},
 ): SessionRow {
   return db.transaction(() => {
     const existing = findAnySessionByClientSessionId(
@@ -235,21 +264,63 @@ export function registerClientSession(
     }
 
     const now = nowUtc()
-    db.query(`
-      UPDATE sessions
-      SET alias = ?,
-          cwd = CASE WHEN ? THEN ? ELSE cwd END,
-          last_activity = ?,
-          generation = generation + 1,
-          released_at = NULL
-      WHERE id = ?
-    `).run(
-      targetAlias,
-      input.cwd !== undefined ? 1 : 0,
-      input.cwd ?? null,
-      now,
-      existing.id,
-    )
+    if (input.owner_token !== undefined) {
+      const sameOwner = existing.owner_token === input.owner_token
+      const ownerLeaseTtlMs = options.ownerLeaseTtlMs ?? LEASE_TTL_MS
+      if (!sameOwner && hasValidOwnerLease(existing, ownerLeaseTtlMs)) {
+        throw new OwnershipConflictError(existing.generation)
+      }
+
+      // A same-owner call is a lease/metadata renewal and deliberately keeps
+      // its generation stable. Acquiring an ownerless/released identity or
+      // taking over an expired owner creates a new lifecycle generation.
+      const bumpGeneration = !sameOwner || existing.released_at !== null
+      db.query(`
+        UPDATE sessions
+        SET alias = ?,
+            cwd = CASE WHEN ? THEN ? ELSE cwd END,
+            last_activity = ?,
+            last_seen_at = CASE WHEN ? THEN NULL ELSE last_seen_at END,
+            owner_seen_at = ?,
+            generation = generation + ?,
+            owner_token = ?,
+            released_at = NULL
+        WHERE id = ?
+      `).run(
+        targetAlias,
+        input.cwd !== undefined ? 1 : 0,
+        input.cwd ?? null,
+        now,
+        bumpGeneration ? 1 : 0,
+        now,
+        bumpGeneration ? 1 : 0,
+        input.owner_token,
+        existing.id,
+      )
+    } else {
+      // Legacy clients intentionally retain last-register-wins semantics.
+      // Clearing owner_token prevents an earlier token holder from renewing
+      // after an owner-unaware client has started a newer generation.
+      db.query(`
+        UPDATE sessions
+        SET alias = ?,
+            cwd = CASE WHEN ? THEN ? ELSE cwd END,
+            last_activity = ?,
+            last_seen_at = CASE WHEN ? THEN NULL ELSE last_seen_at END,
+            generation = generation + 1,
+            owner_token = NULL,
+            owner_seen_at = NULL,
+            released_at = NULL
+        WHERE id = ?
+      `).run(
+        targetAlias,
+        input.cwd !== undefined ? 1 : 0,
+        input.cwd ?? null,
+        now,
+        existing.owner_token !== null ? 1 : 0,
+        existing.id,
+      )
+    }
     return findSessionById(db, existing.id)!
   })()
 }
@@ -259,6 +330,7 @@ export type UnregisterClientSessionResult =
   | 'already_released'
   | 'not_found'
   | 'generation_mismatch'
+  | 'owner_mismatch'
 
 export function unregisterClientSession(
   db: Database,
@@ -266,6 +338,7 @@ export function unregisterClientSession(
     client_kind: ClientKind
     client_session_id: string
     generation: number
+    owner_token?: string
   },
 ): UnregisterClientSessionResult {
   return db.transaction(() => {
@@ -276,20 +349,35 @@ export function unregisterClientSession(
     )
     if (!existing) return 'not_found'
     if (existing.generation !== input.generation) return 'generation_mismatch'
+    if (
+      input.owner_token !== undefined &&
+      existing.owner_token !== input.owner_token
+    ) return 'owner_mismatch'
     if (existing.released_at !== null) return 'already_released'
 
     const result = db.query(`
       UPDATE sessions
-      SET alias = NULL, released_at = ?
+      SET alias = NULL,
+          owner_token = CASE WHEN ? IS NULL THEN NULL ELSE owner_token END,
+          owner_seen_at = NULL,
+          released_at = ?
       WHERE id = ? AND generation = ? AND released_at IS NULL
-    `).run(nowUtc(), existing.id, input.generation)
+        AND (? IS NULL OR owner_token = ?)
+    `).run(
+      input.owner_token ?? null,
+      nowUtc(),
+      existing.id,
+      input.generation,
+      input.owner_token ?? null,
+      input.owner_token ?? null,
+    )
     return Number(result.changes) === 1 ? 'released' : 'generation_mismatch'
   })()
 }
 
 export function releaseSession(db: Database, id: string): void {
   db.query(
-    `UPDATE sessions SET alias = NULL, released_at = ? WHERE id = ?`,
+    `UPDATE sessions SET alias = NULL, owner_token = NULL, owner_seen_at = NULL, released_at = ? WHERE id = ?`,
   ).run(nowUtc(), id)
 }
 
@@ -300,7 +388,7 @@ export function releaseSessionIfGeneration(
 ): boolean {
   const result = db.query(
     `UPDATE sessions
-     SET alias = NULL, released_at = ?
+     SET alias = NULL, owner_token = NULL, owner_seen_at = NULL, released_at = ?
      WHERE id = ? AND generation = ? AND released_at IS NULL`,
   ).run(nowUtc(), id, generation)
   return Number(result.changes) === 1
@@ -321,6 +409,11 @@ export function updateLastActivity(db: Database, id: string): void {
 
 export function updateLastSeen(db: Database, id: string): void {
   db.query('UPDATE sessions SET last_seen_at = ? WHERE id = ?')
+    .run(nowUtc(), id)
+}
+
+export function updateOwnerSeen(db: Database, id: string): void {
+  db.query('UPDATE sessions SET owner_seen_at = ? WHERE id = ?')
     .run(nowUtc(), id)
 }
 
@@ -439,7 +532,7 @@ export function recallMessage(db: Database, input: RecallInput): number {
 export function listAllSessions(db: Database): SessionRow[] {
   return db.query<SessionRow, []>(
     `SELECT id, alias, client_kind, client_session_id, cwd, created_at,
-            last_activity, last_seen_at, generation, released_at
+            last_activity, last_seen_at, generation, owner_token, owner_seen_at, released_at
      FROM sessions
      ORDER BY created_at ASC`,
   ).all()
@@ -496,7 +589,7 @@ export function releaseStaleActiveSessions(
   const placeholders = staleIds.map(() => '?').join(',')
   db.query(
     `UPDATE sessions
-     SET alias = NULL, released_at = ?
+     SET alias = NULL, owner_token = NULL, owner_seen_at = NULL, released_at = ?
      WHERE id IN (${placeholders}) AND released_at IS NULL`,
   ).run(now, ...staleIds)
   return staleIds

--- a/online.ts
+++ b/online.ts
@@ -28,7 +28,14 @@ export function isSessionOnline(
   if (registry.isOnline(session.id)) return true
   if (!session.client_session_id) return false
   return (
-    waiters.isPolling(session.client_kind, session.client_session_id) ||
+    waiters.isPolling(
+      session.client_kind,
+      session.client_session_id,
+      session.owner_token === null ? undefined : {
+        generation: session.generation,
+        ownerToken: session.owner_token,
+      },
+    ) ||
     hasValidLease(session, nowMs)
   )
 }

--- a/schema.sql
+++ b/schema.sql
@@ -8,6 +8,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     last_activity     TEXT NOT NULL,
     last_seen_at      TEXT,
     generation        INTEGER NOT NULL DEFAULT 1,
+    owner_token       TEXT,
+    owner_seen_at     TEXT,
     released_at       TEXT
 );
 

--- a/server.ts
+++ b/server.ts
@@ -18,7 +18,7 @@ import {
   isInitializeRequest,
 } from '@modelcontextprotocol/sdk/types.js'
 import type { Database } from 'bun:sqlite'
-import { openDatabase, createSession, findSessionById, findSessionByAlias, findSessionByCcSessionId, findSessionByClientSessionId, findAnySessionByClientSessionId, registerClientSession, unregisterClientSession, updateLastActivity, updateLastSeen, releaseSessionIfGeneration, insertMessage, insertBroadcast, fetchUnreadForRecipient, markMessagesRead, listAllSessions, recallMessage, countUnreadBySessionId } from './db'
+import { openDatabase, createSession, findSessionById, findSessionByAlias, findSessionByCcSessionId, findSessionByClientSessionId, findAnySessionByClientSessionId, registerClientSession, unregisterClientSession, updateLastActivity, updateLastSeen, updateOwnerSeen, releaseSessionIfGeneration, insertMessage, insertBroadcast, fetchUnreadForRecipient, markMessagesRead, listAllSessions, recallMessage, countUnreadBySessionId, OwnershipConflictError } from './db'
 import { ConnectionRegistry, type PushCallback } from './connections'
 import { setAliasWithCollisionCheck, resolveTarget } from './aliases'
 import { toTaipeiISOString } from './time'
@@ -108,9 +108,46 @@ function requireGeneration(body: Record<string, unknown>): number {
   return value as number
 }
 
+function optionalNonEmptyString(
+  body: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  const value = body[field]
+  if (value === undefined) return undefined
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new RequestValidationError(
+      `${field} must be a non-empty string when provided`,
+    )
+  }
+  return value.trim()
+}
+
+function ownershipMismatchResponse(
+  session: SessionRow,
+  generation: number,
+  ownerToken: string,
+): Response | null {
+  if (session.generation !== generation) {
+    return Response.json({
+      code: 'stale_generation',
+      error: `generation mismatch: current generation is ${session.generation}`,
+      current_generation: session.generation,
+    }, { status: 409 })
+  }
+  if (session.owner_token !== ownerToken) {
+    return Response.json({
+      code: 'owner_mismatch',
+      error: 'owner token mismatch',
+      current_generation: session.generation,
+    }, { status: 409 })
+  }
+  return null
+}
+
 export async function startServer(opts: {
   port: number
   dbPath: string
+  ownerLeaseTtlMs?: number
 }): Promise<ServerHandle> {
   const db: Database = openDatabase(opts.dbPath)
   const registry = new ConnectionRegistry()
@@ -164,12 +201,14 @@ export async function startServer(opts: {
       const client_kind = requireClientKind(body)
       const client_session_id = requireNonEmptyString(body, 'client_session_id')
       const cwd = requireNonEmptyString(body, 'cwd')
+      const owner_token = optionalNonEmptyString(body, 'owner_token')
       const session = registerClientSession(db, {
         alias,
         client_kind,
         client_session_id,
         cwd,
-      })
+        owner_token,
+      }, { ownerLeaseTtlMs: opts.ownerLeaseTtlMs })
       return Response.json({
         session_id: session.id,
         alias: session.alias,
@@ -179,6 +218,13 @@ export async function startServer(opts: {
       const message = error instanceof Error ? error.message : String(error)
       if (error instanceof RequestValidationError) {
         return Response.json({ error: message }, { status: 400 })
+      }
+      if (error instanceof OwnershipConflictError) {
+        return Response.json({
+          code: 'owner_conflict',
+          error: error.message,
+          current_generation: error.currentGeneration,
+        }, { status: 409 })
       }
       if (message.startsWith('alias already taken:')) {
         return Response.json({ error: message }, { status: 409 })
@@ -197,10 +243,12 @@ export async function startServer(opts: {
       const client_kind = requireClientKind(body)
       const client_session_id = requireNonEmptyString(body, 'client_session_id')
       const generation = requireGeneration(body)
+      const owner_token = optionalNonEmptyString(body, 'owner_token')
       const result = unregisterClientSession(db, {
         client_kind,
         client_session_id,
         generation,
+        owner_token,
       })
 
       if (result === 'not_found') {
@@ -212,12 +260,27 @@ export async function startServer(opts: {
           client_kind,
           client_session_id,
         )
-        return Response.json(
-          {
-            error: `generation mismatch: current generation is ${current?.generation ?? 'unknown'}`,
-          },
-          { status: 409 },
+        const error = `generation mismatch: current generation is ${current?.generation ?? 'unknown'}`
+        if (owner_token === undefined) {
+          return Response.json({ error }, { status: 409 })
+        }
+        return Response.json({
+          code: 'stale_generation',
+          error,
+          current_generation: current?.generation ?? null,
+        }, { status: 409 })
+      }
+      if (result === 'owner_mismatch') {
+        const current = findAnySessionByClientSessionId(
+          db,
+          client_kind,
+          client_session_id,
         )
+        return Response.json({
+          code: 'owner_mismatch',
+          error: 'owner token mismatch',
+          current_generation: current?.generation ?? null,
+        }, { status: 409 })
       }
       return Response.json({ status: result })
     } catch (error) {
@@ -239,6 +302,7 @@ export async function startServer(opts: {
       const client_kind = requireClientKind(body)
       const client_session_id = requireNonEmptyString(body, 'client_session_id')
       const generation = requireGeneration(body)
+      const owner_token = optionalNonEmptyString(body, 'owner_token')
       const session = findSessionByClientSessionId(
         db,
         client_kind,
@@ -249,12 +313,22 @@ export async function startServer(opts: {
         return Response.json({ error: 'session not found' }, { status: 404 })
       }
       if (session.generation !== generation) {
+        const error = `generation mismatch: current generation is ${session.generation}`
+        if (owner_token === undefined) {
+          return Response.json({ error }, { status: 409 })
+        }
         return Response.json(
           {
-            error: `generation mismatch: current generation is ${session.generation}`,
+            code: 'stale_generation',
+            error,
+            current_generation: session.generation,
           },
           { status: 409 },
         )
+      }
+      if (owner_token !== undefined) {
+        const mismatch = ownershipMismatchResponse(session, generation, owner_token)
+        if (mismatch) return mismatch
       }
       return Response.json({ messages: readUnreadMessages(session.id) })
     } catch (error) {
@@ -825,15 +899,44 @@ export async function startServer(opts: {
     const parsed = parseInt(timeoutRaw, 10)
     const timeoutS = Math.min(Math.max(Number.isFinite(parsed) ? parsed : 240, 1), 250)
 
-    const session = findSessionByClientSessionId(db, clientKind, clientSessionId)
+    const ownerTokenRaw = url.searchParams.get('owner_token')
+    const generationRaw = url.searchParams.get('generation')
+    if ((ownerTokenRaw === null) !== (generationRaw === null)) {
+      return Response.json({
+        error: 'owner_token and generation must be provided together',
+      }, { status: 400 })
+    }
+    let ownerToken: string | undefined
+    let generation: number | undefined
+    if (ownerTokenRaw !== null && generationRaw !== null) {
+      ownerToken = ownerTokenRaw.trim()
+      generation = Number(generationRaw)
+      if (!ownerToken) {
+        return Response.json({
+          error: 'owner_token must be a non-empty string when provided',
+        }, { status: 400 })
+      }
+      if (!Number.isSafeInteger(generation) || generation < 1) {
+        return Response.json({
+          error: 'generation must be a positive integer when provided',
+        }, { status: 400 })
+      }
+    }
+
+    let session = findSessionByClientSessionId(db, clientKind, clientSessionId)
     if (!session || !session.alias) {
       return Response.json({ status: 'no-session' })
+    }
+    if (ownerToken !== undefined && generation !== undefined) {
+      const mismatch = ownershipMismatchResponse(session, generation, ownerToken)
+      if (mismatch) return mismatch
     }
 
     // Every valid poll renews the client's lease, including immediate unread
     // responses that never enter the waiter registry.
     updateLastSeen(db, session.id)
     updateLastActivity(db, session.id)
+    if (ownerToken !== undefined) updateOwnerSeen(db, session.id)
 
     const initial = countUnreadBySessionId(db, session.id)
     if (initial > 0) {
@@ -851,7 +954,21 @@ export async function startServer(opts: {
       clientSessionId,
       timeoutS * 1000,
       req.signal,
+      ownerToken !== undefined && generation !== undefined
+        ? { ownerToken, generation }
+        : undefined,
     )
+    // Ownership may have changed while this request was blocked. Re-read the
+    // row before exposing mailbox state so an old long-poll cannot wake after
+    // a newer owner has taken over the identity.
+    session = findSessionByClientSessionId(db, clientKind, clientSessionId)
+    if (!session || !session.alias) {
+      return Response.json({ status: 'no-session' })
+    }
+    if (ownerToken !== undefined && generation !== undefined) {
+      const mismatch = ownershipMismatchResponse(session, generation, ownerToken)
+      if (mismatch) return mismatch
+    }
     // Re-check: the waiter may have resolved because of a new message, a
     // timeout, or a client abort. Only the first case yields status=unread.
     const final = countUnreadBySessionId(db, session.id)

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -3,7 +3,7 @@ import { unlinkSync, existsSync, mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Database } from 'bun:sqlite'
-import { openDatabase, createClientSession, createSession, findSessionById, findSessionByAlias, findSessionByClientSessionId, findSessionByCcSessionId, registerClientSession, unregisterClientSession, releaseSession, updateLastActivity, updateLastSeen, insertMessage, fetchUnreadForRecipient, markMessagesRead, insertBroadcast, recallMessage, listAllSessions, deleteExpiredMessages, releaseStaleActiveSessions } from '../db'
+import { openDatabase, createClientSession, createSession, findSessionById, findSessionByAlias, findSessionByClientSessionId, findSessionByCcSessionId, registerClientSession, unregisterClientSession, releaseSession, updateLastActivity, updateLastSeen, insertMessage, fetchUnreadForRecipient, markMessagesRead, insertBroadcast, recallMessage, listAllSessions, deleteExpiredMessages, releaseStaleActiveSessions, OwnershipConflictError } from '../db'
 
 const TEST_DB = ':memory:'
 let db: Database
@@ -295,6 +295,8 @@ test('migration upgrades Phase 2.5 schema without losing data', () => {
   expect(sessionColumns).toContain('cwd')
   expect(sessionColumns).toContain('last_seen_at')
   expect(sessionColumns).toContain('generation')
+  expect(sessionColumns).toContain('owner_token')
+  expect(sessionColumns).toContain('owner_seen_at')
   expect(sessionColumns).not.toContain('cc_session_id')
 
   const sessions = migrated.query<{
@@ -308,9 +310,11 @@ test('migration upgrades Phase 2.5 schema without losing data', () => {
     cwd: string | null
     last_seen_at: string | null
     generation: number
+    owner_token: string | null
+    owner_seen_at: string | null
   }, []>(`
     SELECT id, alias, client_kind, client_session_id, created_at,
-           last_activity, released_at, cwd, last_seen_at, generation
+           last_activity, released_at, cwd, last_seen_at, generation, owner_token, owner_seen_at
     FROM sessions
     ORDER BY id
   `).all()
@@ -326,6 +330,8 @@ test('migration upgrades Phase 2.5 schema without losing data', () => {
       cwd: null,
       last_seen_at: null,
       generation: 1,
+      owner_token: null,
+      owner_seen_at: null,
     },
     {
       id: 'released-id',
@@ -338,6 +344,8 @@ test('migration upgrades Phase 2.5 schema without losing data', () => {
       cwd: null,
       last_seen_at: null,
       generation: 1,
+      owner_token: null,
+      owner_seen_at: null,
     },
   ])
 
@@ -409,6 +417,61 @@ test('registerClientSession upserts identity and increments generation', () => {
   expect(third.id).toBe(first.id)
   expect(third.released_at).toBeNull()
   expect(third.generation).toBe(3)
+})
+
+test('registerClientSession owner CAS acquires, renews, rejects, and takes over expired ownership', () => {
+  const first = registerClientSession(db, {
+    alias: 'owned-one',
+    client_kind: 'codex',
+    client_session_id: 'owned-thread',
+    owner_token: 'owner-a',
+  }, { ownerLeaseTtlMs: 50 })
+  expect(first.owner_token).toBe('owner-a')
+  expect(first.last_seen_at).toBeNull()
+  expect(first.owner_seen_at).not.toBeNull()
+
+  const renewed = registerClientSession(db, {
+    alias: 'owned-renewed',
+    client_kind: 'codex',
+    client_session_id: 'owned-thread',
+    owner_token: 'owner-a',
+  }, { ownerLeaseTtlMs: 50 })
+  expect(renewed.generation).toBe(first.generation)
+  expect(renewed.alias).toBe('owned-renewed')
+
+  expect(() => registerClientSession(db, {
+    alias: 'owned-contender',
+    client_kind: 'codex',
+    client_session_id: 'owned-thread',
+    owner_token: 'owner-b',
+  }, { ownerLeaseTtlMs: 50 })).toThrow(OwnershipConflictError)
+
+  db.query('UPDATE sessions SET owner_seen_at = ? WHERE id = ?')
+    .run(new Date(Date.now() - 51).toISOString(), first.id)
+  const takenOver = registerClientSession(db, {
+    alias: 'owned-taken-over',
+    client_kind: 'codex',
+    client_session_id: 'owned-thread',
+    owner_token: 'owner-b',
+  }, { ownerLeaseTtlMs: 50 })
+  expect(takenOver.generation).toBe(first.generation + 1)
+  expect(takenOver.owner_token).toBe('owner-b')
+})
+
+test('legacy register clears ownership and keeps unconditional generation bumps', () => {
+  const owned = registerClientSession(db, {
+    alias: 'owned-before-legacy',
+    client_kind: 'codex',
+    client_session_id: 'legacy-takeover-thread',
+    owner_token: 'tui-owner',
+  })
+  const legacy = registerClientSession(db, {
+    alias: 'legacy-takeover',
+    client_kind: 'codex',
+    client_session_id: 'legacy-takeover-thread',
+  })
+  expect(legacy.generation).toBe(owned.generation + 1)
+  expect(legacy.owner_token).toBeNull()
 })
 
 test('registerClientSession prefers the active row over released identity history', () => {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -9,7 +9,11 @@ const TEST_PORT = 19876
 const TEST_URL = `http://127.0.0.1:${TEST_PORT}/mcp`
 
 beforeEach(async () => {
-  handle = await startServer({ port: TEST_PORT, dbPath: ':memory:' })
+  handle = await startServer({
+    port: TEST_PORT,
+    dbPath: ':memory:',
+    ownerLeaseTtlMs: 50,
+  })
 })
 
 afterEach(async () => {
@@ -688,6 +692,14 @@ test('/poll validates canonical client identity parameters', async () => {
     `${POLL_URL}?cc_session_id=some-id&client_kind=codex&client_session_id=some-id&timeout_s=1`,
   )
   expect(ambiguous.status).toBe(400)
+
+  const missingGeneration = await fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=some-id&owner_token=owner&timeout_s=1`,
+  )
+  expect(missingGeneration.status).toBe(400)
+  expect(await missingGeneration.json()).toEqual({
+    error: 'owner_token and generation must be provided together',
+  })
 })
 
 test('/poll returns unread immediately when messages are already waiting', async () => {
@@ -1299,6 +1311,227 @@ test('HTTP register upserts active and released peer sessions with increasing ge
   })
 })
 
+test('HTTP register owner CAS acquires, renews, and takes over an expired lease', async () => {
+  const acquired = await (await postJson(REGISTER_URL, {
+    alias: 'owned-codex',
+    client_kind: 'codex',
+    client_session_id: 'owned-codex-session',
+    cwd: '/workspace',
+    owner_token: 'tui-owner-a',
+  })).json()
+  expect(acquired.generation).toBe(1)
+
+  const renewed = await (await postJson(REGISTER_URL, {
+    alias: 'owned-codex-renamed',
+    client_kind: 'codex',
+    client_session_id: 'owned-codex-session',
+    cwd: '/workspace/renamed',
+    owner_token: 'tui-owner-a',
+  })).json()
+  expect(renewed).toEqual({
+    session_id: acquired.session_id,
+    alias: 'owned-codex-renamed',
+    generation: acquired.generation,
+  })
+
+  await Bun.sleep(70)
+  const takenOver = await (await postJson(REGISTER_URL, {
+    alias: 'owned-codex-taken-over',
+    client_kind: 'codex',
+    client_session_id: 'owned-codex-session',
+    cwd: '/workspace/new-owner',
+    owner_token: 'tui-owner-b',
+  })).json()
+  expect(takenOver).toEqual({
+    session_id: acquired.session_id,
+    alias: 'owned-codex-taken-over',
+    generation: acquired.generation + 1,
+  })
+})
+
+test('HTTP register owner CAS rejects a second owner while the lease is active', async () => {
+  const current = await (await postJson(REGISTER_URL, {
+    alias: 'owner-conflict-peer',
+    client_kind: 'codex',
+    client_session_id: 'owner-conflict-session',
+    cwd: '/workspace',
+    owner_token: 'active-owner',
+  })).json()
+
+  const conflict = await postJson(REGISTER_URL, {
+    alias: 'owner-conflict-peer',
+    client_kind: 'codex',
+    client_session_id: 'owner-conflict-session',
+    cwd: '/workspace',
+    owner_token: 'contending-owner',
+  })
+  expect(conflict.status).toBe(409)
+  expect(await conflict.json()).toEqual({
+    code: 'owner_conflict',
+    error: 'session ownership is held by an active client',
+    current_generation: current.generation,
+  })
+})
+
+test('owner registration alone is not reported online before an owned poll starts', async () => {
+  await postJson(REGISTER_URL, {
+    alias: 'owner-not-polling',
+    client_kind: 'codex',
+    client_session_id: 'owner-not-polling-session',
+    cwd: '/workspace',
+    owner_token: 'owner-not-polling-token',
+  })
+  const observer = await makeClient('owner-not-polling-observer')
+  await observer.callTool({ name: 'register', arguments: { role: 'owner-not-polling-observer' } })
+  const sessions = JSON.parse(((await observer.callTool({
+    name: 'list_sessions',
+    arguments: {},
+  })).content as any[])[0].text)
+  expect(sessions.find((session: any) => session.alias === 'owner-not-polling')?.online)
+    .toBe(false)
+  await observer.close()
+})
+
+test('legacy polling does not renew a token owner lease', async () => {
+  await postJson(REGISTER_URL, {
+    alias: 'owner-with-legacy-poll',
+    client_kind: 'codex',
+    client_session_id: 'owner-with-legacy-poll-session',
+    cwd: '/workspace',
+    owner_token: 'expiring-owner',
+  })
+  await Bun.sleep(30)
+  const legacyPoll = fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=owner-with-legacy-poll-session&timeout_s=1`,
+  )
+  await Bun.sleep(30)
+
+  const takeover = await postJson(REGISTER_URL, {
+    alias: 'owner-after-legacy-poll',
+    client_kind: 'codex',
+    client_session_id: 'owner-with-legacy-poll-session',
+    cwd: '/workspace',
+    owner_token: 'new-owner',
+  })
+  expect(takeover.status).toBe(200)
+  await legacyPoll
+})
+
+test('a stale owned long-poll does not make the takeover generation look online', async () => {
+  const oldOwner = await (await postJson(REGISTER_URL, {
+    alias: 'owner-long-poll',
+    client_kind: 'codex',
+    client_session_id: 'owner-long-poll-session',
+    cwd: '/workspace',
+    owner_token: 'old-long-poll-owner',
+  })).json()
+  const oldPoll = fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=owner-long-poll-session` +
+      `&generation=${oldOwner.generation}&owner_token=old-long-poll-owner&timeout_s=2`,
+  )
+  await Bun.sleep(70)
+  const newOwner = await (await postJson(REGISTER_URL, {
+    alias: 'owner-long-poll',
+    client_kind: 'codex',
+    client_session_id: 'owner-long-poll-session',
+    cwd: '/workspace',
+    owner_token: 'new-long-poll-owner',
+  })).json()
+
+  const sender = await makeClient('owner-long-poll-sender')
+  await sender.callTool({ name: 'register', arguments: { role: 'owner-long-poll-sender' } })
+  const sent = JSON.parse(((await sender.callTool({
+    name: 'send',
+    arguments: { to: 'owner-long-poll', message: 'wake only current owner' },
+  })).content as any[])[0].text)
+  expect(sent.delivered_notification).toBe(false)
+
+  const stale = await oldPoll
+  expect(stale.status).toBe(409)
+  expect(await stale.json()).toEqual({
+    code: 'stale_generation',
+    error: `generation mismatch: current generation is ${newOwner.generation}`,
+    current_generation: newOwner.generation,
+  })
+  await sender.close()
+})
+
+test('an owned poll lease does not make a legacy takeover generation look online', async () => {
+  const oldOwner = await (await postJson(REGISTER_URL, {
+    alias: 'owner-to-legacy',
+    client_kind: 'codex',
+    client_session_id: 'owner-to-legacy-session',
+    cwd: '/workspace',
+    owner_token: 'owner-before-legacy',
+  })).json()
+  const oldPoll = fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=owner-to-legacy-session` +
+      `&generation=${oldOwner.generation}&owner_token=owner-before-legacy&timeout_s=2`,
+  )
+  await Bun.sleep(30)
+  const legacy = await (await postJson(REGISTER_URL, {
+    alias: 'owner-to-legacy',
+    client_kind: 'codex',
+    client_session_id: 'owner-to-legacy-session',
+    cwd: '/workspace',
+  })).json()
+
+  const sender = await makeClient('owner-to-legacy-sender')
+  await sender.callTool({ name: 'register', arguments: { role: 'owner-to-legacy-sender' } })
+  const sent = JSON.parse(((await sender.callTool({
+    name: 'send',
+    arguments: { to: 'owner-to-legacy', message: 'legacy owner has not polled' },
+  })).content as any[])[0].text)
+  expect(sent.delivered_notification).toBe(false)
+
+  const stale = await oldPoll
+  expect(stale.status).toBe(409)
+  expect(await stale.json()).toEqual({
+    code: 'stale_generation',
+    error: `generation mismatch: current generation is ${legacy.generation}`,
+    current_generation: legacy.generation,
+  })
+  await sender.close()
+})
+
+test('HTTP ownership is optional and legacy clients retain their existing behavior', async () => {
+  const first = await (await postJson(REGISTER_URL, {
+    alias: 'legacy-ownerless-one',
+    client_kind: 'codex',
+    client_session_id: 'legacy-ownerless-session',
+    cwd: '/workspace/one',
+  })).json()
+  const second = await (await postJson(REGISTER_URL, {
+    alias: 'legacy-ownerless-two',
+    client_kind: 'codex',
+    client_session_id: 'legacy-ownerless-session',
+    cwd: '/workspace/two',
+  })).json()
+  expect(second.generation).toBe(first.generation + 1)
+
+  const poll = await fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=legacy-ownerless-session&timeout_s=1`,
+  )
+  expect(poll.status).toBe(200)
+  expect(await poll.json()).toEqual({ status: 'timeout' })
+
+  const read = await postJson(MESSAGE_READ_URL, {
+    client_kind: 'codex',
+    client_session_id: 'legacy-ownerless-session',
+    generation: second.generation,
+  })
+  expect(read.status).toBe(200)
+  expect(await read.json()).toEqual({ messages: [] })
+
+  const unregister = await postJson(UNREGISTER_URL, {
+    client_kind: 'codex',
+    client_session_id: 'legacy-ownerless-session',
+    generation: second.generation,
+  })
+  expect(unregister.status).toBe(200)
+  expect(await unregister.json()).toEqual({ status: 'released' })
+})
+
 test('HTTP unregister rejects stale generation without killing the current instance', async () => {
   const first = await (await postJson(REGISTER_URL, {
     alias: 'stale-token-one',
@@ -1330,6 +1563,108 @@ test('HTTP unregister rejects stale generation without killing the current insta
   })
   expect(currentResp.status).toBe(200)
   expect(await currentResp.json()).toEqual({ status: 'released' })
+})
+
+test('HTTP ownership guards poll, message read, and unregister', async () => {
+  await postJson(REGISTER_URL, {
+    alias: 'guarded-owner-peer',
+    client_kind: 'codex',
+    client_session_id: 'guarded-owner-session',
+    cwd: '/workspace',
+  })
+  const current = await (await postJson(REGISTER_URL, {
+    alias: 'guarded-owner-peer',
+    client_kind: 'codex',
+    client_session_id: 'guarded-owner-session',
+    cwd: '/workspace',
+    owner_token: 'guarded-owner',
+  })).json()
+
+  const poll = await fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=guarded-owner-session` +
+      `&generation=${current.generation}&owner_token=wrong-owner&timeout_s=1`,
+  )
+  expect(poll.status).toBe(409)
+  expect(await poll.json()).toEqual({
+    code: 'owner_mismatch',
+    error: 'owner token mismatch',
+    current_generation: current.generation,
+  })
+
+  const stalePoll = await fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=guarded-owner-session` +
+      `&generation=${current.generation - 1}&owner_token=guarded-owner&timeout_s=1`,
+  )
+  expect(stalePoll.status).toBe(409)
+  expect(await stalePoll.json()).toEqual({
+    code: 'stale_generation',
+    error: `generation mismatch: current generation is ${current.generation}`,
+    current_generation: current.generation,
+  })
+
+  const read = await postJson(MESSAGE_READ_URL, {
+    client_kind: 'codex',
+    client_session_id: 'guarded-owner-session',
+    generation: current.generation,
+    owner_token: 'wrong-owner',
+  })
+  expect(read.status).toBe(409)
+  expect(await read.json()).toEqual({
+    code: 'owner_mismatch',
+    error: 'owner token mismatch',
+    current_generation: current.generation,
+  })
+
+  const staleRead = await postJson(MESSAGE_READ_URL, {
+    client_kind: 'codex',
+    client_session_id: 'guarded-owner-session',
+    generation: current.generation - 1,
+    owner_token: 'guarded-owner',
+  })
+  expect(staleRead.status).toBe(409)
+  expect(await staleRead.json()).toEqual({
+    code: 'stale_generation',
+    error: `generation mismatch: current generation is ${current.generation}`,
+    current_generation: current.generation,
+  })
+
+  const unregister = await postJson(UNREGISTER_URL, {
+    client_kind: 'codex',
+    client_session_id: 'guarded-owner-session',
+    generation: current.generation,
+    owner_token: 'wrong-owner',
+  })
+  expect(unregister.status).toBe(409)
+  expect(await unregister.json()).toEqual({
+    code: 'owner_mismatch',
+    error: 'owner token mismatch',
+    current_generation: current.generation,
+  })
+
+  const validPoll = await fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=guarded-owner-session` +
+      `&generation=${current.generation}&owner_token=guarded-owner&timeout_s=1`,
+  )
+  expect(validPoll.status).toBe(200)
+  expect(await validPoll.json()).toEqual({ status: 'timeout' })
+
+  const validUnregister = await postJson(UNREGISTER_URL, {
+    client_kind: 'codex',
+    client_session_id: 'guarded-owner-session',
+    generation: current.generation,
+    owner_token: 'guarded-owner',
+  })
+  expect(validUnregister.status).toBe(200)
+  expect(await validUnregister.json()).toEqual({ status: 'released' })
+
+  const repeatedUnregister = await postJson(UNREGISTER_URL, {
+    client_kind: 'codex',
+    client_session_id: 'guarded-owner-session',
+    generation: current.generation,
+    owner_token: 'guarded-owner',
+  })
+  expect(repeatedUnregister.status).toBe(200)
+  expect(await repeatedUnregister.json()).toEqual({ status: 'already_released' })
 })
 
 test('HTTP register reports an active alias conflict', async () => {
@@ -1383,6 +1718,10 @@ test('HTTP register validates JSON, required fields, and client_kind', async () 
       body: { alias: 'peer', client_kind: 'codex', client_session_id: 'thread', cwd: '' },
       error: 'cwd is required and must be a non-empty string',
     },
+    {
+      body: { alias: 'peer', client_kind: 'codex', client_session_id: 'thread', cwd: '/workspace', owner_token: '' },
+      error: 'owner_token must be a non-empty string when provided',
+    },
   ]
 
   for (const invalidCase of invalidCases) {
@@ -1414,6 +1753,10 @@ test('HTTP unregister validates identity and generation fields', async () => {
       body: { client_kind: 'codex', client_session_id: 'thread', generation: 1.5 },
       error: 'generation is required and must be a positive integer',
     },
+    {
+      body: { client_kind: 'codex', client_session_id: 'thread', generation: 1, owner_token: '' },
+      error: 'owner_token must be a non-empty string when provided',
+    },
   ]
 
   for (const invalidCase of invalidCases) {
@@ -1436,6 +1779,10 @@ test('HTTP message read validates identity and generation fields', async () => {
     {
       body: { client_kind: 'codex', client_session_id: 'thread', generation: 0 },
       error: 'generation is required and must be a positive integer',
+    },
+    {
+      body: { client_kind: 'codex', client_session_id: 'thread', generation: 1, owner_token: '' },
+      error: 'owner_token must be a non-empty string when provided',
     },
   ]
 

--- a/tests/online.test.ts
+++ b/tests/online.test.ts
@@ -15,6 +15,8 @@ function session(overrides: Partial<SessionRow> = {}): SessionRow {
     last_activity: '2026-07-24T00:00:00.000Z',
     last_seen_at: null,
     generation: 1,
+    owner_token: null,
+    owner_seen_at: null,
     released_at: null,
     ...overrides,
   }

--- a/tests/waiters.test.ts
+++ b/tests/waiters.test.ts
@@ -118,3 +118,59 @@ test('one completed wait does not clear another wait for the same client identit
   await second
   expect(reg.isPolling('codex', 'same-id')).toBe(false)
 })
+
+test('owned polling liveness is scoped to generation and owner token', async () => {
+  const reg = new UnreadWaiterRegistry()
+  const abort = new AbortController()
+  const ownership = { generation: 2, ownerToken: 'owner-two' }
+  const waiting = reg.wait(
+    'session',
+    'codex',
+    'same-id',
+    60_000,
+    abort.signal,
+    ownership,
+  )
+
+  expect(reg.isPolling('codex', 'same-id')).toBe(false)
+  expect(reg.isPolling('codex', 'same-id', ownership)).toBe(true)
+  expect(reg.isPolling('codex', 'same-id', {
+    generation: 1,
+    ownerToken: 'owner-one',
+  })).toBe(false)
+
+  abort.abort()
+  await waiting
+})
+
+test('polling keys cannot collide through delimiters in identities or owner tokens', async () => {
+  const reg = new UnreadWaiterRegistry()
+  const firstAbort = new AbortController()
+  const secondAbort = new AbortController()
+  const firstOwnership = { generation: 1, ownerToken: 'x:owner:2:y' }
+  const secondOwnership = { generation: 2, ownerToken: 'y' }
+  const first = reg.wait(
+    'first-session',
+    'codex',
+    'a',
+    60_000,
+    firstAbort.signal,
+    firstOwnership,
+  )
+  const second = reg.wait(
+    'second-session',
+    'codex',
+    'a:owner:1:x',
+    60_000,
+    secondAbort.signal,
+    secondOwnership,
+  )
+
+  firstAbort.abort()
+  await first
+  expect(reg.isPolling('codex', 'a', firstOwnership)).toBe(false)
+  expect(reg.isPolling('codex', 'a:owner:1:x', secondOwnership)).toBe(true)
+
+  secondAbort.abort()
+  await second
+})

--- a/types.ts
+++ b/types.ts
@@ -14,6 +14,8 @@ export interface SessionRow {
   last_activity: string // ISO 8601 UTC
   last_seen_at: string | null // ISO 8601 UTC
   generation: number
+  owner_token: string | null
+  owner_seen_at: string | null // ISO 8601 UTC; ownership CAS lease only
   released_at: string | null // ISO 8601 UTC; NULL means active
 }
 

--- a/waiters.ts
+++ b/waiters.ts
@@ -16,12 +16,25 @@ export interface Waiter {
   resolve: () => void
 }
 
+export interface PollOwnership {
+  generation: number
+  ownerToken: string
+}
+
 export class UnreadWaiterRegistry {
   private waiters = new Map<string, Set<Waiter>>()
   private polling = new Map<string, number>()
 
-  private pollingKey(clientKind: ClientKind, clientSessionId: string): string {
-    return `${clientKind}:${clientSessionId}`
+  private pollingKey(
+    clientKind: ClientKind,
+    clientSessionId: string,
+    ownership?: PollOwnership,
+  ): string {
+    return JSON.stringify(
+      ownership
+        ? [clientKind, clientSessionId, 'owner', ownership.generation, ownership.ownerToken]
+        : [clientKind, clientSessionId, 'legacy'],
+    )
   }
 
   /**
@@ -42,8 +55,9 @@ export class UnreadWaiterRegistry {
     clientSessionId: string,
     timeoutMs: number,
     abortSignal?: AbortSignal,
+    ownership?: PollOwnership,
   ): Promise<void> {
-    const pollingKey = this.pollingKey(clientKind, clientSessionId)
+    const pollingKey = this.pollingKey(clientKind, clientSessionId, ownership)
     this.polling.set(pollingKey, (this.polling.get(pollingKey) ?? 0) + 1)
     try {
       await new Promise<void>((resolve) => {
@@ -98,8 +112,12 @@ export class UnreadWaiterRegistry {
   }
 
   /** True if this kind-qualified client identity is currently polling. */
-  isPolling(clientKind: ClientKind, clientSessionId: string): boolean {
-    return this.polling.has(this.pollingKey(clientKind, clientSessionId))
+  isPolling(
+    clientKind: ClientKind,
+    clientSessionId: string,
+    ownership?: PollOwnership,
+  ): boolean {
+    return this.polling.has(this.pollingKey(clientKind, clientSessionId, ownership))
   }
 
   /**


### PR DESCRIPTION
## 摘要

Issue #7 決議（方案 A）的第一階段：Switchboard server 端的 ownership CAS。
小回實作、阿宇檢查改寫，待小回終檢。

## 內容

- **schema/migration**：sessions 新增 nullable \`owner_token\`、\`owner_seen_at\`；ownership lease 與既有 poll lease（\`last_seen_at\`）分離
- **\`POST /register\` 選填 \`owner_token\`（CAS）**：無主可取得、同 owner 續租不 bump generation、原 owner lease 過期才可接手；活 lease 期間第二個 owner 被 \`409 code=owner_conflict\` 拒絕（與 alias 衝突的 409 可區分）
- **owner-aware \`/poll\`／\`/messages/read\`／\`/unregister\`**：409 body 標明 \`stale_generation\` 或 \`owner_mismatch\`；owned long-poll 等待結束後重查 ownership，舊 owner 的長連線不會在新 owner 接手後被喚醒
- **waiter liveness key 綁 generation＋token**：舊 owner 的 poll 不會讓 takeover 世代誤判在線
- **向下相容（硬要求）**：不帶 token 的 register/poll/read/unregister 行為與回應 shape 完全不變，測試釘住
- 兩份 README 的 HTTP endpoints 章節同步補上 owner_token 說明

## 驗證

- \`bun test\`：171 pass / 0 fail（新增 12 條整合測試：CAS 三情境、雙 owner 互搶、legacy 相容、stale/owner mismatch、poll takeover liveness、owned→legacy、unregister 冪等重試、migration、waiter key collision）
- \`tsc --noEmit\` 通過

## 未含

- \`clients/opencode-plugin/switchboard.ts\` 的 409 降級修正——開工時 PR #8 尚未進 main，分支上還沒有 clients/ 目錄，隨第二階段（TUI-target plugin）一併處理
- 第二階段：TUI-target plugin 本體

merge 鍵照慣例保留給阿童。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJvBuVgYtpZmJbDpPshrLZ