### PR TITLE
TUI 門鈴 plugin（#7 第二階段）

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ Codex-kind recipients are only written to when they are online at insert time �
   same-owner call is a lease renewal that keeps its generation, and a second
   owner is rejected with `409 {code: "owner_conflict"}` while the current
   owner's lease is alive. Token-less registers keep last-register-wins
-  semantics and clear any stored owner token.
+  semantics and clear any stored owner token. A token-less fallback can pass
+  `"respect_owner": true` to receive the same `owner_conflict` instead of
+  preempting a live owner; omitting it preserves legacy behavior.
 - `POST /unregister` — graceful peer sign-off. JSON body:
   `{ "client_kind": ..., "client_session_id": ..., "generation": <int> }`.
   The generation must match the current row — a delayed unregister from an

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -180,6 +180,8 @@ Role 名字挑一個能描述這個 session 在做什麼的（例如 `tools`、`
   舊 owner 會遞增 generation；同 owner 重呼叫視為 lease 續租、generation 不動；
   現任 owner 的 lease 還活著時，第二個 owner 會被 `409 {code: "owner_conflict"}`
   拒絕。不帶 token 的註冊維持 last-register-wins 語意，並會清掉已存的 owner token。
+  無 token 的 fallback 可帶 `"respect_owner": true`，遇到活 owner 時同樣回
+  `owner_conflict` 而不搶 ownership；省略此欄位則維持舊行為。
 - `POST /unregister` — peer 優雅下線。JSON body：
   `{ "client_kind": ..., "client_session_id": ..., "generation": <int> }`。
   generation 必須與現值相符——舊 instance 遲到的下線請求動不了新 instance（409）。回傳

--- a/clients/opencode-plugin/README.md
+++ b/clients/opencode-plugin/README.md
@@ -1,49 +1,91 @@
-# Switchboard OpenCode Plugin
+# Switchboard OpenCode Plugins
 
-讓 OpenCode（headless server）接上 Switchboard 的通訊 plugin：
-總機門鈴、per-session 分機、分機名跟隨 session 標題、認領（claim）指引，全在這一個檔案裡。
+OpenCode 端分成兩個獨立 plugin target：
 
-這裡是**版控正本**；現役檔案在 `~/.opencode/plugins/switchboard.ts`，兩邊要保持一致。
+- `switchboard.ts`：server target，負責 headless 總機與 30 分鐘活躍窗內的 server-side 分機。
+- `switchboard-tui.ts`：TUI target，只負責目前畫面上的 session，提供 direct TUI 門鈴、toast 與桌面通知。
 
-## 部署
+OpenCode v1 不允許同一個 module 同時 export `server` 與 `tui`，所以兩者必須維持獨立檔案。這裡是**版控正本**，部署時用複製，不要 symlink，避免 repo 開發中的半成品直接生效。
+
+## Headless Server Plugin
+
+現役檔案放在 `~/.opencode/plugins/switchboard.ts`：
 
 ```bash
 cp clients/opencode-plugin/switchboard.ts ~/.opencode/plugins/switchboard.ts
 systemctl --user restart opencode-server
 ```
 
-用**複製**、不要 symlink——repo 開發中的半成品不該直接生效；改完測過再手動部署。
-
-改了現役檔案（hotfix）之後，記得抄回 repo 開 PR，別讓兩邊漂移：
-
-```bash
-cp ~/.opencode/plugins/switchboard.ts clients/opencode-plugin/switchboard.ts
-```
-
-## 門鈴旗 `SWITCHBOARD_DOORBELL=1`（重要）
-
-Plugin 開頭有守門：
+只有 headless 的 `opencode-server.service` 設定 `SWITCHBOARD_DOORBELL=1`。Plugin 開頭以此旗標守門：
 
 ```typescript
 if (process.env.SWITCHBOARD_DOORBELL !== "1") return {}
 ```
 
-- **只有 headless 的 systemd unit（opencode-server.service）設這個環境變數**——它是唯一的總機。
-- TUI 或其他 OpenCode 行程**不設旗**，plugin 直接停用。
-- 為什麼：OpenCode 會同時載入 global 與 project 兩份 plugin，多個行程都搶著註冊總機的話，
-  generation 會被互相踢著往上灌（實測灌到 10），訊息投遞跟著錯亂。
+- Headless server 是唯一註冊 `小回(codex)` 的總機。
+- 一般 TUI 或其他 OpenCode server 行程不設旗，不會碰總機 generation。
+- 為什麼：多個行程若共用 stable instance UUID 註冊總機，會互相 bump generation，造成 lifecycle 與訊息投遞錯亂。
 
-## 行為摘要
+## TUI Plugin
 
-- **總機**：以 alias（預設 `小回(codex)`）常駐 Switchboard，輪詢收信；有新信就喚醒（或建立）常駐 session 處理。
-- **分機**：每個活躍 session 掛自己的門鈴，alias 格式 `<總機名>-<標題slug>-<sessionID前8碼>`，30 分鐘活躍窗，過期自動下線。
-- **名隨標題**：session 改標題（PATCH `/session/:id` 的 `title`）＝改分機名，plugin 監聽 `session.updated` 自動重新註冊。
-- **認領**：喚醒 prompt 內附 claim 指引，session 可用 MCP `register(client_kind, client_session_id)` 認領自己的分機身分（Switchboard PR #5 的統一門牌機制）。
-- **節流**：同未讀計數不重複喚醒；poll timeout 與讀信成功後歸零水位，避免新信被舊水位壓住。
+TUI plugin 不走 server plugin 的 auto-discovery，必須放進 OpenCode config 目錄並列在 `tui.json`：
 
-## 已知陷阱（實戰記錄）
+```bash
+mkdir -p ~/.config/opencode/plugins
+cp clients/opencode-plugin/switchboard-tui.ts ~/.config/opencode/plugins/switchboard-tui.ts
+```
 
-- **無鈴死信箱**：session 自行用 MCP `register` 註冊的獨立 alias 沒有門鈴，投遞進去沒人醒。只投總機或分機格式的 alias。
-- **plugin 初始化不能 await 自家 API**：lazy init 是被 session API 觸發的，init 裡 await `client.session.list()` 會把 POST /session 整個鎖死。要預熱就用 `setTimeout` 延後。
-- **存在性檢查走 SDK**：`client.baseUrl` 拿不到值，用它拼 URL 的檢查永遠失敗（症狀：每次總機喚醒都開新常駐 session）。一律用 `client.session.list()`。
-- **OpenCode 不理 SIGTERM**：重啟交給 systemd（unit 已設 `KillSignal=SIGKILL`），不要手動 kill 後乾等。
+把以下欄位**合併**進 `~/.config/opencode/tui.json`，保留既有設定：
+
+```json
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "plugin": ["./plugins/switchboard-tui.ts"],
+  "attention": {
+    "enabled": true,
+    "notifications": true
+  }
+}
+```
+
+安裝或修改 TUI plugin 後要完整退出再重開 TUI。它不需要 `SWITCHBOARD_DOORBELL`；如 daemon 不在預設 `http://127.0.0.1:9876`，啟動 TUI 前另設 `SWITCHBOARD_URL`。
+
+### TUI 行為
+
+- 每 750 ms 只在本機比對 `api.route.current`；只有 route/session metadata 改變或 standby retry 才重新註冊，收信 poll 則獨立長駐。
+- 每個 TUI 行程產生一顆 process-local `owner_token`，以 ownership CAS 管理目前 session；同 owner 改標題只 renew，不 bump generation。
+- 第二個視窗打開同一 session 時，`owner_conflict` 會進 standby 並顯示一次提示；每 5 秒重試，原 owner 正常離開後數秒內接手，crash 則在 5 分鐘 owner lease 過期後接手。
+- `stale_generation`／`owner_mismatch` 會立即停止該 session 的喚醒，直到使用者切走再切回才重新競逐；絕不降級成 signal-only prompt。
+- 收信順序為 owner-aware poll → read → TUI toast／blurred-only desktop notification → `promptAsync`。Toast 顯示分機名與封數；desktop notification 只顯示封數，兩者都不含信件內文。已讀 batch 會在同一 TUI 行程記憶體內序列化重試，直到 `promptAsync` 成功；行程被強制終止仍不具 durable ack 保證。
+- 不會自動切換 route。切去別的 session 或退出 TUI 時，會帶 generation 與 owner token unregister。
+
+## 分工
+
+- **總機**：只有 headless server plugin 負責，常駐接收寄給 `小回(codex)` 的信。
+- **Headless 分機 fallback**：server plugin 維持 30 分鐘活躍窗，讓 attach 或近期 server session 可被喚醒。
+- **畫面上的 session**：TUI plugin 以 owner token 接手精確的 route lifecycle。Headless 舊 generation 收到 409 時會安靜停止，不再送重複的 signal-only prompt。
+- **分機命名**：alias 格式 `小回-<標題slug>-<session ID 末 8 碼>`；短碼真的衝突時改用完整 session ID。標題變更會由目前 owner renew alias。
+- **認領**：喚醒 prompt 會指示 session 用 MCP `register(client_kind, client_session_id)` 認領自己的分機，後續回覆沿用同一門牌。
+
+## 手動驗收
+
+目前沒有 OpenCode TUI plugin harness；部署前至少走完以下實機驗收：
+
+1. 確認 Switchboard daemon 與 headless server 已啟動，安裝 TUI plugin 後完整重開 OpenCode。
+2. 直接執行 `opencode`（不是 attach），進入一個具名 session；確認 Switchboard 出現對應 `小回-<slug>-<suffix>` 分機且在線。
+3. 從另一個 session 寄信到該分機；確認目前 TUI 顯示不含內文的 toast，terminal 失焦時才送 desktop notification，並由原 session 收到完整 prompt；畫面不可被自動切 route。
+4. 另開第二個 TUI 並進入同一 session；確認只提示一次「此 session 門鈴由另一視窗持有」，沒有 generation 互踢。關閉 owner 視窗後，standby 視窗應在數秒內取得門鈴。
+5. 在兩個不同 session 間切換；確認舊分機 generation-safe unregister、新分機註冊，切換期間沒有把信送進錯的 session。
+6. 在 owner poll 中製造 stale generation 或 owner mismatch；確認該 TUI 安靜停止喚醒，沒有 signal-only prompt 或重複 toast。
+7. 用 `opencode attach` 連 headless server 再重跑收信；確認 TUI owner 與 headless fallback 不會重複喚醒。
+
+## 已知陷阱
+
+- **手動註冊不等於有門鈴**：session 只用 MCP `register` 建 alias，仍需要 headless 或 TUI plugin 的 poll 才能自動喚醒。
+- **server plugin 初始化不能 await 自家 API**：lazy init 可能由 session API 觸發；初始化時 await `client.session.list()` 會形成 server/plugin 互鎖。預熱一律延後非同步執行。
+- **存在性檢查走 SDK**：`client.baseUrl` 不是可用的 public property；session 查詢使用 `client.session.list()`。
+- **409 不是 endpoint outage**：generation/owner 409 必須停止喚醒；只有連線失敗或其他非 409 錯誤才允許既有 server plugin 走 signal-only fallback。
+- **總機 409 是部署異常**：總機理論上只有一個有旗行程；若它真的遇到 stale 409，會停止喚醒並等待 systemd 重啟，而不是反向搶回可能仍活著的新 generation。
+- **OpenCode 不理 SIGTERM**：headless 重啟交給 systemd（unit 已設 `KillSignal=SIGKILL`），不要手動 kill 後乾等。
+
+若現役檔案有 hotfix，修完後要同步抄回 repo 再開 PR，避免版控正本漂移。

--- a/clients/opencode-plugin/switchboard-tui.ts
+++ b/clients/opencode-plugin/switchboard-tui.ts
@@ -1,0 +1,488 @@
+/**
+ * Switchboard doorbell for an interactive OpenCode TUI.
+ *
+ * This is deliberately a TUI-target plugin, separate from switchboard.ts's
+ * server target. It owns only the session currently shown by this TUI, so it
+ * never registers the headless switchboard identity or historical sessions.
+ */
+import type { TuiPlugin, TuiPluginModule } from "@opencode-ai/plugin/tui"
+
+const SWITCHBOARD_URL = (process.env.SWITCHBOARD_URL ?? "http://127.0.0.1:9876").replace(/\/$/, "")
+const ROUTE_CHECK_MS = 750
+const STANDBY_RETRY_MS = 5_000
+const REQUEST_TIMEOUT_MS = 15_000
+const POLL_TIMEOUT_S = 240
+
+type SessionTarget = {
+  id: string
+  alias: string
+  directory: string
+}
+
+type Peer = SessionTarget & {
+  preferredAlias: string
+  generation: number
+  stopping: boolean
+  abort: AbortController
+}
+
+type Selection = SessionTarget & {
+  blocked: boolean
+  retryAt: number
+  conflictNotified: boolean
+  unavailableNotified: boolean
+}
+
+type RegisterResult =
+  | { status: "registered"; alias: string; generation: number }
+  | { status: "conflict" }
+  | { status: "stale" }
+  | { status: "unavailable" }
+
+type ReadResult =
+  | { status: "messages"; messages: any[] }
+  | { status: "stale" }
+  | { status: "unavailable" }
+
+type PendingDelivery = {
+  messages: any[]
+  notified: boolean
+  delivery: Promise<"ok" | "unavailable"> | null
+}
+
+function sessionSlug(title: string | undefined): string {
+  const slug = (title ?? "session")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 24)
+  return slug || "session"
+}
+
+function sessionAlias(id: string, title: string | undefined, fullId = false): string {
+  return `小回-${sessionSlug(title)}-${fullId ? id : id.slice(-8)}`
+}
+
+async function responseJson(response: Response): Promise<any> {
+  return response.json().catch(() => null)
+}
+
+function requestSignal(abort?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+  return abort ? AbortSignal.any([abort, timeout]) : timeout
+}
+
+const tui: TuiPlugin = async (api) => {
+  const ownerToken = crypto.randomUUID()
+  let disposed = false
+  let selection: Selection | null = null
+  let peer: Peer | null = null
+  let reconciling: Promise<void> | null = null
+  const pendingBySession = new Map<string, PendingDelivery>()
+
+  function currentTarget(): SessionTarget | null {
+    const route = api.route.current
+    if (route.name !== "session") return null
+    const sessionID = route.params?.sessionID
+    if (typeof sessionID !== "string" || !sessionID) return null
+    const info = api.state.session.get(sessionID)
+    return {
+      id: sessionID,
+      alias: sessionAlias(sessionID, info?.title),
+      directory: info?.directory ?? api.state.path.directory ?? process.cwd(),
+    }
+  }
+
+  async function postRegister(target: SessionTarget, alias: string, abort?: AbortSignal): Promise<Response> {
+    return fetch(`${SWITCHBOARD_URL}/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        alias,
+        client_kind: "codex",
+        client_session_id: target.id,
+        cwd: target.directory,
+        owner_token: ownerToken,
+      }),
+      signal: requestSignal(abort),
+    })
+  }
+
+  async function registerTarget(target: SessionTarget, abort?: AbortSignal): Promise<RegisterResult> {
+    try {
+      let alias = target.alias
+      let response = await postRegister(target, alias, abort)
+      let data = await responseJson(response)
+
+      if (response.status === 409 && data?.code === "owner_conflict") {
+        return { status: "conflict" }
+      }
+      if (response.status === 409 && (
+        data?.code === "stale_generation" || data?.code === "owner_mismatch"
+      )) {
+        return { status: "stale" }
+      }
+
+      // A plain 409 is an alias collision. Keep the readable short suffix for
+      // the normal case, but retry with the stable full session ID if needed.
+      if (response.status === 409) {
+        alias = sessionAlias(target.id, api.state.session.get(target.id)?.title, true)
+        response = await postRegister(target, alias, abort)
+        data = await responseJson(response)
+        if (response.status === 409 && data?.code === "owner_conflict") {
+          return { status: "conflict" }
+        }
+        if (response.status === 409 && (
+          data?.code === "stale_generation" || data?.code === "owner_mismatch"
+        )) {
+          return { status: "stale" }
+        }
+      }
+
+      if (!response.ok || !Number.isSafeInteger(data?.generation)) {
+        return { status: "unavailable" }
+      }
+      return {
+        status: "registered",
+        alias: typeof data.alias === "string" ? data.alias : alias,
+        generation: data.generation,
+      }
+    } catch {
+      return { status: "unavailable" }
+    }
+  }
+
+  async function unregisterPeer(current: Peer): Promise<void> {
+    current.stopping = true
+    current.abort.abort()
+    await fetch(`${SWITCHBOARD_URL}/unregister`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_kind: "codex",
+        client_session_id: current.id,
+        generation: current.generation,
+        owner_token: ownerToken,
+      }),
+      signal: requestSignal(),
+    }).catch(() => {})
+  }
+
+  function stopWaking(current: Peer): void {
+    current.stopping = true
+    current.abort.abort()
+    if (peer !== current) return
+    peer = null
+    if (selection?.id === current.id) selection.blocked = true
+  }
+
+  async function readMessages(current: Peer): Promise<ReadResult> {
+    try {
+      const response = await fetch(`${SWITCHBOARD_URL}/messages/read`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_kind: "codex",
+          client_session_id: current.id,
+          generation: current.generation,
+          owner_token: ownerToken,
+        }),
+        signal: requestSignal(current.abort.signal),
+      })
+      const data = await responseJson(response)
+      if (response.status === 409 && (
+        data?.code === "stale_generation" || data?.code === "owner_mismatch"
+      )) {
+        return { status: "stale" }
+      }
+      if (!response.ok || !Array.isArray(data?.messages)) {
+        return { status: "unavailable" }
+      }
+      return { status: "messages", messages: data.messages }
+    } catch {
+      return { status: current.stopping ? "stale" : "unavailable" }
+    }
+  }
+
+  async function wake(current: Peer): Promise<"ok" | "stale" | "unavailable"> {
+    let pending = pendingBySession.get(current.id)
+    if (!pending) {
+      const result = await readMessages(current)
+      if (result.status !== "messages") return result.status
+      if (result.messages.length === 0) return "ok"
+      pending = { messages: result.messages, notified: false, delivery: null }
+      // /messages/read has already acknowledged this batch on the daemon. Keep
+      // it locally until promptAsync succeeds so a transient OpenCode/TUI error
+      // does not turn the acknowledged mail into a lost wake.
+      pendingBySession.set(current.id, pending)
+    }
+
+    if (pending.delivery) return pending.delivery
+    const delivery = (async (): Promise<"ok" | "unavailable"> => {
+      const summary = `${current.alias} 收到 ${pending.messages.length} 封新訊息`
+      if (!pending.notified) {
+        pending.notified = true
+        try {
+          api.ui.toast({
+            title: "Switchboard",
+            message: summary,
+            variant: "info",
+            duration: 5_000,
+          })
+        } catch {}
+        await api.attention.notify({
+          title: "Switchboard",
+          message: `收到 ${pending.messages.length} 封新訊息`,
+          notification: { when: "blurred" },
+          sound: false,
+        }).catch(() => {})
+      }
+
+      const claimHint = `\n\n請先用 switchboard MCP register 認領本分機:` +
+        ` client_kind='codex', client_session_id='${current.id}'。` +
+        `認領後回覆會使用同一個門牌「${current.alias}」。`
+      const text = `Switchboard 站內信（${pending.messages.length} 封,已代你標記已讀）:\n\n` +
+        pending.messages.map((message: any) =>
+          `— 來自 ${message.sender_alias ?? message.sender_id}` +
+          `（${message.created_at}${message.is_broadcast ? ",廣播" : ""}）:\n${message.content}`
+        ).join("\n\n") +
+        `${claimHint}\n\n請依訊息內容處理;需要回覆時用你的 switchboard MCP send 工具(收件人通常是 main=阿宇)。`
+
+      try {
+        const prompted = await api.client.session.promptAsync({
+          sessionID: current.id,
+          parts: [{ type: "text", text }],
+        })
+        if (prompted.error) return "unavailable"
+        if (pendingBySession.get(current.id) === pending) pendingBySession.delete(current.id)
+        return "ok"
+      } catch {
+        return "unavailable"
+      }
+    })()
+    pending.delivery = delivery
+    try {
+      return await delivery
+    } finally {
+      if (pendingBySession.get(current.id) === pending && pending.delivery === delivery) {
+        pending.delivery = null
+      }
+    }
+  }
+
+  async function poll(current: Peer): Promise<void> {
+    while (!disposed && !current.stopping) {
+      try {
+        if (pendingBySession.has(current.id)) {
+          const outcome = await wake(current)
+          if (outcome === "stale") {
+            stopWaking(current)
+            return
+          }
+          if (outcome === "unavailable") await waitForRetry(current.abort.signal)
+          continue
+        }
+        const url = new URL(`${SWITCHBOARD_URL}/poll`)
+        url.searchParams.set("client_kind", "codex")
+        url.searchParams.set("client_session_id", current.id)
+        url.searchParams.set("generation", String(current.generation))
+        url.searchParams.set("owner_token", ownerToken)
+        url.searchParams.set("timeout_s", String(POLL_TIMEOUT_S))
+        const response = await fetch(url, {
+          signal: AbortSignal.any([
+            current.abort.signal,
+            AbortSignal.timeout((POLL_TIMEOUT_S + 15) * 1_000),
+          ]),
+        })
+        const data = await responseJson(response)
+
+        if (response.status === 409 && (
+          data?.code === "stale_generation" || data?.code === "owner_mismatch"
+        )) {
+          stopWaking(current)
+          return
+        }
+        if (!response.ok) throw new Error(`poll failed: ${response.status}`)
+
+        if (data?.status === "unread") {
+          const outcome = await wake(current)
+          if (outcome === "stale") {
+            stopWaking(current)
+            return
+          }
+          if (outcome === "unavailable") await waitForRetry(current.abort.signal)
+        } else if (data?.status === "no-session") {
+          current.stopping = true
+          if (peer === current) {
+            peer = null
+            if (selection?.id === current.id) selection.retryAt = Date.now() + STANDBY_RETRY_MS
+          }
+          return
+        }
+      } catch {
+        if (disposed || current.stopping) return
+        await waitForRetry(current.abort.signal)
+      }
+    }
+  }
+
+  async function waitForRetry(signal: AbortSignal): Promise<void> {
+    if (signal.aborted) return
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, STANDBY_RETRY_MS)
+      signal.addEventListener("abort", () => {
+        clearTimeout(timer)
+        resolve()
+      }, { once: true })
+    })
+  }
+
+  async function applyRegistration(target: SessionTarget, existing?: Peer): Promise<void> {
+    const abort = existing?.abort ?? new AbortController()
+    const result = await registerTarget(target, abort.signal)
+    if (!selection || selection.id !== target.id || disposed) {
+      if (result.status === "registered") {
+        await unregisterPeer({
+          ...target,
+          preferredAlias: target.alias,
+          alias: result.alias,
+          generation: result.generation,
+          stopping: false,
+          abort,
+        })
+      }
+      return
+    }
+
+    if (result.status === "registered") {
+      selection.conflictNotified = false
+      selection.unavailableNotified = false
+      if (existing) {
+        if (existing.generation !== result.generation) {
+          // A legacy owner may have taken the identity between route ticks.
+          // Abort the in-flight poll tied to the old generation and start a
+          // fresh peer; mutating generation underneath a long-poll would make
+          // its eventual 409 look like a loss of the newly reacquired owner.
+          existing.stopping = true
+          existing.abort.abort()
+          const restarted: Peer = {
+            ...target,
+            preferredAlias: target.alias,
+            alias: result.alias,
+            generation: result.generation,
+            stopping: false,
+            abort: new AbortController(),
+          }
+          peer = restarted
+          void poll(restarted)
+          return
+        }
+        existing.alias = result.alias
+        existing.preferredAlias = target.alias
+        existing.directory = target.directory
+        existing.generation = result.generation
+        return
+      }
+      const started: Peer = {
+        ...target,
+        preferredAlias: target.alias,
+        alias: result.alias,
+        generation: result.generation,
+        stopping: false,
+        abort,
+      }
+      peer = started
+      void poll(started)
+      return
+    }
+
+    if (existing) {
+      existing.stopping = true
+      existing.abort.abort()
+      if (peer === existing) peer = null
+    }
+    if (result.status === "stale") {
+      selection.blocked = true
+      return
+    }
+    selection.retryAt = Date.now() + STANDBY_RETRY_MS
+    if (result.status === "conflict" && !selection.conflictNotified) {
+      selection.conflictNotified = true
+      api.ui.toast({
+        title: "Switchboard",
+        message: "此 session 門鈴由另一視窗持有",
+        variant: "info",
+        duration: 5_000,
+      })
+    } else if (result.status === "unavailable" && !selection.unavailableNotified) {
+      selection.unavailableNotified = true
+      api.ui.toast({
+        title: "Switchboard",
+        message: "門鈴暫時無法連線，稍後重試",
+        variant: "warning",
+        duration: 5_000,
+      })
+    }
+  }
+
+  async function reconcile(): Promise<void> {
+    while (!disposed) {
+      const target = currentTarget()
+      if (selection?.id !== target?.id) {
+        const previous = peer
+        peer = null
+        selection = target ? {
+          ...target,
+          blocked: false,
+          retryAt: 0,
+          conflictNotified: false,
+          unavailableNotified: false,
+        } : null
+        if (previous) await unregisterPeer(previous)
+        continue
+      }
+      if (!target || !selection || selection.blocked) return
+
+      selection.alias = target.alias
+      selection.directory = target.directory
+      if (peer) {
+        if (peer.preferredAlias !== target.alias || peer.directory !== target.directory) {
+          await applyRegistration(target, peer)
+          continue
+        }
+        return
+      }
+      if (Date.now() < selection.retryAt) return
+      await applyRegistration(target)
+      return
+    }
+  }
+
+  function scheduleReconcile(): void {
+    if (reconciling || disposed) return
+    reconciling = reconcile().finally(() => {
+      reconciling = null
+    })
+  }
+
+  const routeTimer = setInterval(scheduleReconcile, ROUTE_CHECK_MS)
+  ;(routeTimer as any).unref?.()
+  scheduleReconcile()
+
+  api.lifecycle.onDispose(async () => {
+    disposed = true
+    clearInterval(routeTimer)
+    await reconciling?.catch(() => {})
+    const current = peer
+    peer = null
+    selection = null
+    if (current) await unregisterPeer(current)
+  })
+}
+
+const plugin: TuiPluginModule & { id: string } = {
+  id: "switchboard.tui-doorbell",
+  tui,
+}
+
+export default plugin

--- a/clients/opencode-plugin/switchboard.ts
+++ b/clients/opencode-plugin/switchboard.ts
@@ -31,15 +31,21 @@ type SessionInfo = {
 
 type SessionPeer = {
   sessionId: string
+  info: SessionInfo
   alias: string
   generation: number | null
   lastActivityAt: number
   lastWokenCount: number
   wakePending: boolean
+  wakeStopped: boolean
   stopping: boolean
   pollAbort: AbortController | null
   idleTimer: ReturnType<typeof setTimeout> | null
+  registering: Promise<void> | null
 }
+
+const STALE_READ = Symbol("stale-read")
+type MessageReadResult = any[] | null | typeof STALE_READ
 
 function responseData<T = any>(result: any): T | null {
   return (result?.data ?? result) as T ?? null
@@ -83,6 +89,7 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
     ? readFileSync(SESSION_ID_PATH, "utf8").trim() || null
     : null
   let stopping = false
+  let totalWakeStopped = false
   let wakePending = false // 節流:session 忙碌中不重複塞喚醒 prompt
   // 未讀節流:Switchboard 尚無讀信端點,未讀數不會下降——同一計數只喚醒一次,
   // 否則會陷入 poll→喚醒→idle→poll 的無限迴圈(2026-07-29 實戰血淚)
@@ -141,8 +148,9 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
     return sessionId
   }
 
-  async function registerPeer(peer: SessionPeer, info: SessionInfo, requestedAlias = peer.alias): Promise<void> {
-    let alias = requestedAlias
+  async function registerPeerNow(peer: SessionPeer): Promise<void> {
+    const info = peer.info
+    let alias = sessionAlias(info)
     let res = await fetch(`${SWITCHBOARD_URL}/register`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -151,8 +159,18 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
         client_kind: "codex",
         client_session_id: peer.sessionId,
         cwd: info.directory ?? directory ?? process.cwd(),
+        respect_owner: true,
       }),
+      signal: AbortSignal.timeout(15_000),
     })
+    let data = await res.json().catch(() => null)
+    if (res.status === 409 && data?.code === "owner_conflict") {
+      peer.generation = null
+      peer.wakePending = false
+      peer.wakeStopped = true
+      log(`session peer standing by behind active owner session=${peer.sessionId}`)
+      return
+    }
     // The short ID suffix is readable and normally unique. On a real collision,
     // retry with the full stable session ID rather than stealing another alias.
     if (res.status === 409) {
@@ -165,14 +183,51 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
           client_kind: "codex",
           client_session_id: peer.sessionId,
           cwd: info.directory ?? directory ?? process.cwd(),
+          respect_owner: true,
         }),
+        signal: AbortSignal.timeout(15_000),
       })
+      data = await res.json().catch(() => null)
+      if (res.status === 409 && data?.code === "owner_conflict") {
+        peer.generation = null
+        peer.wakePending = false
+        peer.wakeStopped = true
+        log(`session peer standing by behind active owner session=${peer.sessionId}`)
+        return
+      }
     }
-    if (!res.ok) throw new Error(`register failed: ${res.status} ${await res.text()}`)
-    const data = await res.json()
+    if (!res.ok || !data) throw new Error(`register failed: ${res.status} ${JSON.stringify(data)}`)
     peer.alias = data.alias
     peer.generation = data.generation
+    peer.lastWokenCount = 0
+    peer.wakePending = false
+    peer.wakeStopped = false
     log(`registered session=${peer.sessionId} alias=${peer.alias} generation=${peer.generation}`)
+  }
+
+  function updatePeerInfo(peer: SessionPeer, info: SessionInfo): void {
+    peer.info = {
+      ...peer.info,
+      ...info,
+      title: info.title ?? peer.info.title,
+      directory: info.directory ?? peer.info.directory,
+    }
+  }
+
+  async function registerPeer(peer: SessionPeer, info?: SessionInfo): Promise<void> {
+    if (info) updatePeerInfo(peer, info)
+    const previous = peer.registering
+    const current = (async () => {
+      await previous?.catch(() => {})
+      if (peer.stopping || stopping) return
+      await registerPeerNow(peer)
+    })()
+    peer.registering = current
+    try {
+      await current
+    } finally {
+      if (peer.registering === current) peer.registering = null
+    }
   }
 
   async function unregisterPeer(peer: SessionPeer): Promise<void> {
@@ -190,7 +245,7 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
     }).catch(() => {})
   }
 
-  async function readPeerMessages(peer: SessionPeer): Promise<any[] | null> {
+  async function readPeerMessages(peer: SessionPeer): Promise<MessageReadResult> {
     if (peer.generation === null) return null
     try {
       const res = await fetch(`${SWITCHBOARD_URL}/messages/read`, {
@@ -202,6 +257,9 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
           generation: peer.generation,
         }),
       })
+      // A 409 means a newer generation/owner now controls this identity. It is
+      // not an endpoint outage and must never trigger a signal-only prompt.
+      if (res.status === 409) return STALE_READ
       if (!res.ok) return null
       const data = await res.json()
       return Array.isArray(data.messages) ? data.messages : null
@@ -217,6 +275,13 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
     }
     peer.wakePending = true
     const messages = await readPeerMessages(peer)
+    if (messages === STALE_READ) {
+      peer.wakePending = false
+      peer.wakeStopped = true
+      peer.generation = null
+      log(`session wake stopped after stale read session=${peer.sessionId}`)
+      return
+    }
     if (messages) peer.lastWokenCount = 0
     const claimHint = `\n\n請先用 switchboard MCP register 認領本分機:` +
       ` client_kind='codex', client_session_id='${peer.sessionId}'。` +
@@ -245,9 +310,19 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
     log(`woke session=${peer.sessionId} unread=${count} content=${messages ? "full" : "signal-only"}`)
   }
 
-  async function pollPeer(peer: SessionPeer, info: SessionInfo): Promise<void> {
+  async function pollPeer(peer: SessionPeer): Promise<void> {
     while (!peer.stopping && !stopping) {
       try {
+        if (peer.wakeStopped) {
+          // Foreground TUI ownership may disappear through a graceful exit or
+          // lease expiry after a crash. Retry the CAS-aware fallback register
+          // instead of waiting for no-session (an expired owner row remains
+          // active and would otherwise strand this peer forever).
+          await new Promise((r) => setTimeout(r, 5000))
+          if (peer.stopping || stopping) break
+          await registerPeer(peer)
+          continue
+        }
         peer.pollAbort = new AbortController()
         const timeout = AbortSignal.timeout((POLL_TIMEOUT_S + 15) * 1000)
         const signal = AbortSignal.any([peer.pollAbort.signal, timeout])
@@ -267,7 +342,7 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
           peer.lastWokenCount = 0
         } else if (data.status === "no-session") {
           log(`session peer released remotely; re-registering session=${peer.sessionId}`)
-          await registerPeer(peer, info)
+          await registerPeer(peer)
         }
       } catch (e) {
         if (peer.stopping || stopping) break
@@ -299,6 +374,10 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
     peer.stopping = true
     if (peer.idleTimer) clearTimeout(peer.idleTimer)
     peer.pollAbort?.abort()
+    // A register may already be on the wire. Let its bounded request settle so
+    // unregister sees the final generation instead of leaving a successful
+    // late registration orphaned without a poller.
+    await peer.registering?.catch(() => {})
     await unregisterPeer(peer)
     log(`unregistered session=${id} reason=${reason}`)
   }
@@ -307,6 +386,7 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
     if (!info.id || info.id === sessionId || info.title === "小回 switchboard 常駐站") return
     const existing = peers.get(info.id)
     if (existing) {
+      updatePeerInfo(existing, info)
       existing.lastActivityAt = Math.max(existing.lastActivityAt, activityAt)
       schedulePeerExpiry(existing)
       return
@@ -314,14 +394,17 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
     if (Date.now() - activityAt >= SESSION_ACTIVE_MS) return
     const peer: SessionPeer = {
       sessionId: info.id,
+      info,
       alias: sessionAlias(info),
       generation: null,
       lastActivityAt: activityAt,
       lastWokenCount: 0,
       wakePending: false,
+      wakeStopped: false,
       stopping: false,
       pollAbort: null,
       idleTimer: null,
+      registering: null,
     }
     peers.set(info.id, peer)
     schedulePeerExpiry(peer)
@@ -330,7 +413,7 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
       if (peer.stopping || stopping) {
         await unregisterPeer(peer)
       } else {
-        pollPeer(peer, info)
+        pollPeer(peer)
       }
     } catch (e) {
       if (peers.get(info.id) === peer) peers.delete(info.id)
@@ -352,14 +435,15 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
     }
   }
 
-  /** 讀取並標記自己的信件（POST /messages/read,generation-guarded）。端點不存在或驗證失敗時回 null 走降級。 */
-  async function readOwnMessages(): Promise<any[] | null> {
+  /** 讀取並標記自己的信件。409 代表身分已失效；其他失敗才允許走 signal-only 降級。 */
+  async function readOwnMessages(): Promise<MessageReadResult> {
     try {
       const res = await fetch(`${SWITCHBOARD_URL}/messages/read`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ client_kind: "codex", client_session_id: instanceId, generation }),
       })
+      if (res.status === 409) return STALE_READ
       if (!res.ok) return null
       const data = await res.json()
       return Array.isArray(data.messages) ? data.messages : null
@@ -376,6 +460,12 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
     wakePending = true
     const sid = await ensureSession()
     const messages = await readOwnMessages()
+    if (messages === STALE_READ) {
+      wakePending = false
+      totalWakeStopped = true
+      log("main switchboard wake stopped after stale read")
+      return
+    }
     if (messages) lastWokenCount = 0 // 信已讀走,水位歸零,下一封新信才叫得醒
     const text = messages && messages.length
       ? `Switchboard 站內信（${messages.length} 封,已代你標記已讀）:\n\n` +
@@ -396,7 +486,7 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
   }
 
   async function pollLoop(): Promise<void> {
-    while (!stopping) {
+    while (!stopping && !totalWakeStopped) {
       try {
         const url = `${SWITCHBOARD_URL}/poll?client_kind=codex&client_session_id=${instanceId}&timeout_s=${POLL_TIMEOUT_S}`
         const res = await fetch(url, { signal: AbortSignal.timeout((POLL_TIMEOUT_S + 15) * 1000) })
@@ -478,11 +568,12 @@ export const SwitchboardPeer = async ({ client, directory }: any) => {
 
       if (event.type === "session.updated" && info) {
         const peer = peers.get(info.id)
+        if (peer) updatePeerInfo(peer, info)
         const alias = sessionAlias(info)
         const fallbackAlias = sessionAlias(info, true)
         if (peer && alias !== peer.alias && fallbackAlias !== peer.alias) {
           try {
-            await registerPeer(peer, info, alias)
+            await registerPeer(peer, info)
           } catch (e) {
             // Keep polling under the previous registration and retry on a later update.
             log(`session alias update failed session=${peer.sessionId} alias=${alias}: ${e}`)

--- a/db.ts
+++ b/db.ts
@@ -208,6 +208,7 @@ export interface RegisterClientSessionInput {
   client_session_id: string
   cwd?: string | null
   owner_token?: string
+  respect_owner?: boolean
 }
 
 export class OwnershipConflictError extends Error {
@@ -253,6 +254,14 @@ export function registerClientSession(
       }
       const id = createClientSession(db, input)
       return findSessionById(db, id)!
+    }
+
+    if (
+      input.owner_token === undefined &&
+      input.respect_owner === true &&
+      hasValidOwnerLease(existing, options.ownerLeaseTtlMs ?? LEASE_TTL_MS)
+    ) {
+      throw new OwnershipConflictError(existing.generation)
     }
 
     const targetAlias = input.alias ?? existing.alias

--- a/server.ts
+++ b/server.ts
@@ -122,6 +122,18 @@ function optionalNonEmptyString(
   return value.trim()
 }
 
+function optionalBoolean(
+  body: Record<string, unknown>,
+  field: string,
+): boolean | undefined {
+  const value = body[field]
+  if (value === undefined) return undefined
+  if (typeof value !== 'boolean') {
+    throw new RequestValidationError(`${field} must be a boolean when provided`)
+  }
+  return value
+}
+
 function ownershipMismatchResponse(
   session: SessionRow,
   generation: number,
@@ -202,12 +214,14 @@ export async function startServer(opts: {
       const client_session_id = requireNonEmptyString(body, 'client_session_id')
       const cwd = requireNonEmptyString(body, 'cwd')
       const owner_token = optionalNonEmptyString(body, 'owner_token')
+      const respect_owner = optionalBoolean(body, 'respect_owner')
       const session = registerClientSession(db, {
         alias,
         client_kind,
         client_session_id,
         cwd,
         owner_token,
+        respect_owner,
       }, { ownerLeaseTtlMs: opts.ownerLeaseTtlMs })
       return Response.json({
         session_id: session.id,
@@ -934,7 +948,12 @@ export async function startServer(opts: {
 
     // Every valid poll renews the client's lease, including immediate unread
     // responses that never enter the waiter registry.
-    updateLastSeen(db, session.id)
+    // A legacy fallback poll may watch an owner-controlled identity so it can
+    // reclaim after release. It must not renew the foreground owner's online
+    // lease or make a stale fallback look deliverable.
+    if (ownerToken !== undefined || session.owner_token === null) {
+      updateLastSeen(db, session.id)
+    }
     updateLastActivity(db, session.id)
     if (ownerToken !== undefined) updateOwnerSeen(db, session.id)
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1373,6 +1373,93 @@ test('HTTP register owner CAS rejects a second owner while the lease is active',
   })
 })
 
+test('respect_owner lets a legacy fallback stand by without taking an active owner', async () => {
+  const current = await (await postJson(REGISTER_URL, {
+    alias: 'foreground-owner',
+    client_kind: 'codex',
+    client_session_id: 'foreground-owner-session',
+    cwd: '/workspace',
+    owner_token: 'foreground-token',
+  })).json()
+
+  const fallback = await postJson(REGISTER_URL, {
+    alias: 'foreground-owner',
+    client_kind: 'codex',
+    client_session_id: 'foreground-owner-session',
+    cwd: '/workspace',
+    respect_owner: true,
+  })
+  expect(fallback.status).toBe(409)
+  expect(await fallback.json()).toEqual({
+    code: 'owner_conflict',
+    error: 'session ownership is held by an active client',
+    current_generation: current.generation,
+  })
+
+  // Omitting the opt-in flag preserves the legacy last-register-wins path.
+  const legacy = await postJson(REGISTER_URL, {
+    alias: 'foreground-owner',
+    client_kind: 'codex',
+    client_session_id: 'foreground-owner-session',
+    cwd: '/workspace',
+  })
+  expect(legacy.status).toBe(200)
+  expect((await legacy.json()).generation).toBe(current.generation + 1)
+})
+
+test('respect_owner fallback can take over after the owner lease expires', async () => {
+  const current = await (await postJson(REGISTER_URL, {
+    alias: 'expiring-foreground',
+    client_kind: 'codex',
+    client_session_id: 'expiring-foreground-session',
+    cwd: '/workspace',
+    owner_token: 'expiring-foreground-token',
+  })).json()
+  const blocked = await postJson(REGISTER_URL, {
+    alias: 'expiring-foreground',
+    client_kind: 'codex',
+    client_session_id: 'expiring-foreground-session',
+    cwd: '/workspace',
+    respect_owner: true,
+  })
+  expect(blocked.status).toBe(409)
+
+  await Bun.sleep(70)
+  const takeover = await postJson(REGISTER_URL, {
+    alias: 'expiring-foreground',
+    client_kind: 'codex',
+    client_session_id: 'expiring-foreground-session',
+    cwd: '/workspace',
+    respect_owner: true,
+  })
+  expect(takeover.status).toBe(200)
+  expect((await takeover.json()).generation).toBe(current.generation + 1)
+})
+
+test('legacy fallback polling does not make an owner-controlled identity online', async () => {
+  await postJson(REGISTER_URL, {
+    alias: 'foreground-not-polled',
+    client_kind: 'codex',
+    client_session_id: 'foreground-not-polled-session',
+    cwd: '/workspace',
+    owner_token: 'foreground-not-polled-token',
+  })
+  const fallbackPoll = fetch(
+    `${POLL_URL}?client_kind=codex&client_session_id=foreground-not-polled-session&timeout_s=1`,
+  )
+  await Bun.sleep(30)
+
+  const sender = await makeClient('fallback-liveness-sender')
+  await sender.callTool({ name: 'register', arguments: { role: 'fallback-liveness-sender' } })
+  const sent = JSON.parse(((await sender.callTool({
+    name: 'send',
+    arguments: { to: 'foreground-not-polled', message: 'owner is not polling' },
+  })).content as any[])[0].text)
+  expect(sent.delivered_notification).toBe(false)
+  expect((await (await fallbackPoll).json()).status).toBe('unread')
+  await sender.close()
+})
+
 test('owner registration alone is not reported online before an owned poll starts', async () => {
   await postJson(REGISTER_URL, {
     alias: 'owner-not-polling',
@@ -1721,6 +1808,10 @@ test('HTTP register validates JSON, required fields, and client_kind', async () 
     {
       body: { alias: 'peer', client_kind: 'codex', client_session_id: 'thread', cwd: '/workspace', owner_token: '' },
       error: 'owner_token must be a non-empty string when provided',
+    },
+    {
+      body: { alias: 'peer', client_kind: 'codex', client_session_id: 'thread', cwd: '/workspace', respect_owner: 'yes' },
+      error: 'respect_owner must be a boolean when provided',
     },
   ]
 


### PR DESCRIPTION
## 摘要

Issue #7 決議（方案 A）的第二階段，closes #7。小回實作、阿宇檢查（本次無改寫），待小回終檢與實機驗收。

## 內容

- **新增 \`clients/opencode-plugin/switchboard-tui.ts\`**（TUI target，與 server target 依 OpenCode v1 限制分檔）：
  - 只管理 \`api.route.current\` 指向的 session，750ms 輕量比對，不自動切 route
  - process-local owner token ＋ 第一階段的 ownership CAS；owner_conflict 進 standby（5 秒重試、單次提示）
  - \`stale_generation\`／\`owner_mismatch\` 一律安靜停止喚醒，絕不 signal-only 降級
  - 收信：owner-aware poll → read → toast（不含內文）→ blurred-only 桌面通知 → promptAsync；已讀 batch 在行程內重試到 promptAsync 成功，daemon 已 ack 的信不會因暫時性 TUI 錯誤丟失
- **server plugin 修正**（上階段跳過的那條＋共存機制）：read 409 與端點掛掉分流；分機註冊改帶 \`respect_owner\`，活 owner 期間 headless fallback 待命，owner 正常離開數秒內接手、crash 則等 lease 過期；register 序列化＋15 秒 timeout，teardown 等 in-flight register 落定
- **server 端小幅擴充**：token-less \`/register\` 可帶 \`respect_owner: true\` 換取 owner_conflict 而非搶佔；不帶旗的 legacy 行為完全不變（測試釘住）。legacy standby poll 不再替 owner 持有的 identity 續 online lease
- **文件**：clients README 全面改寫（雙 plugin 部署、分工、七步手動驗收）；root 中英 README 補 respect_owner

## 驗證

- \`bun test\`：174 pass / 0 fail；root \`tsc --noEmit\` 通過
- plugin 另以 OpenCode 1.18.9 實際 d.ts 跑 strict \`tsc --noEmit\` 通過；兩個 plugin \`bun build --no-bundle\` 成功
- **尚未做**：實機 TUI 驗收（七步驟見 clients/opencode-plugin/README.md）——merge 前由阿宇＋阿童實機走一輪

merge 鍵照慣例保留給阿童。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJvBuVgYtpZmJbDpPshrLZ