### PR TITLE
list_sessions 只回線上 session，retention 清掉死掉的 session row

### DIFF
--- a/db.ts
+++ b/db.ts
@@ -565,6 +565,23 @@ export function deleteExpiredMessages(db: Database): number {
 }
 
 /**
+ * Delete session rows nobody can reach any more: already released, idle beyond
+ * the retention window, and not referenced by any surviving message. Every
+ * client start leaves a row behind, so without this the table grows forever
+ * and every list_sessions call pays for the whole history.
+ */
+export function deleteStaleSessionRows(db: Database, retentionDays: number): number {
+  const info = db.query(`
+    DELETE FROM sessions
+    WHERE released_at IS NOT NULL
+      AND datetime(last_activity) < datetime('now', ?)
+      AND id NOT IN (SELECT sender_id FROM messages)
+      AND id NOT IN (SELECT recipient_id FROM messages)
+  `).run(`-${retentionDays} days`)
+  return Number(info.changes)
+}
+
+/**
  * Release sessions that look orphaned: alive in DB (released_at IS NULL) but
  * either (a) not currently connected to any transport, and (b) no activity
  * within staleThresholdMs. The later of lease renewal and general activity is

--- a/retention.ts
+++ b/retention.ts
@@ -1,9 +1,10 @@
 import type { Database } from 'bun:sqlite'
-import { deleteExpiredMessages, releaseStaleActiveSessions } from './db'
+import { deleteExpiredMessages, deleteStaleSessionRows, releaseStaleActiveSessions } from './db'
 import type { ConnectionRegistry } from './connections'
 
 const ONE_HOUR_MS = 60 * 60 * 1000
 const STALE_SESSION_THRESHOLD_MS = 24 * ONE_HOUR_MS
+const SESSION_ROW_RETENTION_DAYS = 30
 
 export interface RetentionHandle {
   stop(): void
@@ -42,14 +43,30 @@ export function startRetentionLoop(
     }
   }
 
+  const staleRowsTick = () => {
+    try {
+      const deleted = deleteStaleSessionRows(db, SESSION_ROW_RETENTION_DAYS)
+      if (deleted > 0) {
+        process.stderr.write(`switchboard: retention deleted ${deleted} session row(s)
+`)
+      }
+    } catch (err) {
+      process.stderr.write(`switchboard: session rows retention error: ${err}
+`)
+    }
+  }
+
   // Run once immediately, then schedule periodic ticks.
   messagesTick()
   sessionsTick()
+  staleRowsTick()
   const messagesTimer = setInterval(messagesTick, ONE_HOUR_MS)
+  const staleRowsTimer = setInterval(staleRowsTick, ONE_HOUR_MS)
   const sessionsTimer = setInterval(sessionsTick, 2 * ONE_HOUR_MS)
   return {
     stop() {
       clearInterval(messagesTimer)
+      clearInterval(staleRowsTimer)
       clearInterval(sessionsTimer)
     },
   }

--- a/server.ts
+++ b/server.ts
@@ -542,7 +542,9 @@ export async function startServer(opts: {
         },
         {
           name: 'list_sessions',
-          description: 'List all registered sessions with online status.',
+          description:
+            'List the sessions that are currently online. '
+            + 'Offline history is not returned — query the sessions table directly if you need it.',
           inputSchema: { type: 'object' as const, properties: {} },
         },
         {
@@ -790,14 +792,16 @@ export async function startServer(opts: {
       }
 
       if (name === 'list_sessions') {
-        const all = listAllSessions(db)
-        const result = all.map(s => ({
-          session_id: s.id,
-          alias: s.alias,
-          online: isSessionOnline(s, registry, waiters),
-          created_at: toTaipeiISOString(s.created_at),
-          last_activity: toTaipeiISOString(s.last_activity),
-        }))
+        // Online only: offline rows pile up into the hundreds and flood the caller's context
+        const result = listAllSessions(db)
+          .filter(s => isSessionOnline(s, registry, waiters))
+          .map(s => ({
+            session_id: s.id,
+            alias: s.alias,
+            online: true,
+            created_at: toTaipeiISOString(s.created_at),
+            last_activity: toTaipeiISOString(s.last_activity),
+          }))
         return {
           content: [{ type: 'text', text: JSON.stringify(result) }],
         }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -3,7 +3,7 @@ import { unlinkSync, existsSync, mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Database } from 'bun:sqlite'
-import { openDatabase, createClientSession, createSession, findSessionById, findSessionByAlias, findSessionByClientSessionId, findSessionByCcSessionId, registerClientSession, unregisterClientSession, releaseSession, updateLastActivity, updateLastSeen, insertMessage, fetchUnreadForRecipient, markMessagesRead, insertBroadcast, recallMessage, listAllSessions, deleteExpiredMessages, releaseStaleActiveSessions, OwnershipConflictError } from '../db'
+import { openDatabase, createClientSession, createSession, findSessionById, findSessionByAlias, findSessionByClientSessionId, findSessionByCcSessionId, registerClientSession, unregisterClientSession, releaseSession, updateLastActivity, updateLastSeen, insertMessage, fetchUnreadForRecipient, markMessagesRead, insertBroadcast, recallMessage, listAllSessions, deleteExpiredMessages, releaseStaleActiveSessions, deleteStaleSessionRows, OwnershipConflictError } from '../db'
 
 const TEST_DB = ':memory:'
 let db: Database
@@ -728,4 +728,48 @@ test('releaseStaleActiveSessions uses last_seen_at when a lease has been renewed
 
   expect(releaseStaleActiveSessions(db, [], 24 * 60 * 60_000)).toEqual([])
   expect(findSessionByAlias(db, 'leased')?.id).toBe(id)
+})
+
+// --- deleteStaleSessionRows ---
+
+const THIRTY_DAYS_MS = 30 * 86400_000
+
+test('deleteStaleSessionRows removes released rows idle beyond the window', () => {
+  const gone = createSession(db, { alias: 'gone' })
+  releaseSession(db, gone)
+  backdateLastActivity(db, gone, THIRTY_DAYS_MS + 86400_000)
+
+  expect(deleteStaleSessionRows(db, 30)).toBe(1)
+  expect(findSessionById(db, gone)).toBeNull()
+})
+
+test('deleteStaleSessionRows keeps rows still referenced by a message', () => {
+  const sender = createSession(db, { alias: 'sender' })
+  const recipient = createSession(db, { alias: 'recipient' })
+  insertMessage(db, { sender_id: sender, recipient_id: recipient, broadcast_id: null, content: 'keeps them alive' })
+  for (const id of [sender, recipient]) {
+    releaseSession(db, id)
+    backdateLastActivity(db, id, THIRTY_DAYS_MS + 86400_000)
+  }
+
+  expect(deleteStaleSessionRows(db, 30)).toBe(0)
+  expect(findSessionById(db, sender)).not.toBeNull()
+  expect(findSessionById(db, recipient)).not.toBeNull()
+})
+
+test('deleteStaleSessionRows keeps active rows however old they are', () => {
+  const active = createSession(db, { alias: 'active' })
+  backdateLastActivity(db, active, THIRTY_DAYS_MS * 12)
+
+  expect(deleteStaleSessionRows(db, 30)).toBe(0)
+  expect(findSessionById(db, active)).not.toBeNull()
+})
+
+test('deleteStaleSessionRows keeps recently released rows', () => {
+  const recent = createSession(db, { alias: 'recent' })
+  releaseSession(db, recent)
+  backdateLastActivity(db, recent, 86400_000) // yesterday
+
+  expect(deleteStaleSessionRows(db, 30)).toBe(0)
+  expect(findSessionById(db, recent)).not.toBeNull()
 })

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -810,7 +810,8 @@ test('/poll renews a lease used by list_sessions and delivered_notification', as
     name: 'list_sessions',
     arguments: {},
   })).content as any[])[0].text)
-  expect(before.find((s: any) => s.alias === 'leased-codex')?.online).toBe(false)
+  // Not online now means absent from the listing, not present-and-flagged.
+  expect(before.some((s: any) => s.alias === 'leased-codex')).toBe(false)
 
   const poll = fetch(
     `${POLL_URL}?client_kind=codex&client_session_id=leased-codex-id&timeout_s=1`,
@@ -1474,8 +1475,8 @@ test('owner registration alone is not reported online before an owned poll start
     name: 'list_sessions',
     arguments: {},
   })).content as any[])[0].text)
-  expect(sessions.find((session: any) => session.alias === 'owner-not-polling')?.online)
-    .toBe(false)
+  // Not online now means absent from the listing, not present-and-flagged.
+  expect(sessions.some((session: any) => session.alias === 'owner-not-polling')).toBe(false)
   await observer.close()
 })
 


### PR DESCRIPTION
家裡阿宇 8/25 推的分支，公司分機代開 PR。

- `list_sessions` 只回目前線上的 session（離線歷史累積到近百筆，每次查都灌爆 caller 的 context）
- retention loop 每小時刪除：已釋放、30 天無活動、且沒有任何訊息引用的 session row
- 測試：`bun test` 182 pass（含與另外兩支分支合併後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MHeUU6Q6z7MBbJJKvcVEi