### PR TITLE
heartbeat 內嵌台北星期，間隔可由訂閱端設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ Codex-kind recipients are only written to when they are online at insert time �
 - `GET /monitor?cc_session_id=<uuid>` — persistent chunked text stream for Claude Code's `Monitor` tool. One line per event:
   - `hello <alias>` — baseline, emitted once on connect when inbox is empty
   - `inbox <N> <alias>` — unread waiting (on connect) or a new `send`/`broadcast` arrived
-  - `heartbeat <iso-ts>` — emitted every ~2 hr of silence as a visible time tick (a silent space byte goes out every 240s to keep Bun's `idleTimeout` from cutting the stream)
+  - `heartbeat <iso-ts>` — emitted every 4 hr of silence as a visible time tick, e.g. `heartbeat 2026-04-24(五)T13:38:25.000+08:00`; the `(X)` after the date is the Taipei weekday, so subscribers read it rather than deriving it and getting the UTC/Taipei day boundary wrong (a silent space byte goes out every 240s to keep Bun's `idleTimeout` from cutting the stream)
+  - Append `&heartbeat_secs=N` to the `/monitor` URL to change that interval (clamped to 240..86400). Every heartbeat wake is a cold start for an LLM subscriber — the prompt cache has expired, so the whole context is rewritten at cache-write price — which makes the interval a direct cost knob: doubling it halves the idle burn.
 
 Bun's `idleTimeout` caps individual `/poll` waits at ~250s, so shims loop. `/monitor` stays open for the life of the session; clients should wrap `curl -sN` in a reconnect loop so a daemon restart self-heals.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -209,7 +209,8 @@ Role 名字挑一個能描述這個 session 在做什麼的（例如 `tools`、`
 - `GET /monitor?cc_session_id=<uuid>` — 為 Claude Code 的 `Monitor` tool 設計的長駐 chunked text stream，每行一個 event：
   - `hello <alias>` — 連上時的 baseline，inbox 空時才發
   - `inbox <N> <alias>` — 連上時有未讀、或有新的 `send` / `broadcast` 到
-  - `heartbeat <iso-ts>` — 每 ~2 hr 靜默時發一次的可見時間 tick（每 240s 還會發一個無訊息空白 byte 維持 Bun `idleTimeout` 不砍 stream）
+  - `heartbeat <iso-ts>` — 每 4 hr 靜默時發一次的可見時間 tick，例如 `heartbeat 2026-04-24(五)T13:38:25.000+08:00`；日期後面的 `(X)` 是台北時間的星期，訂閱端直接讀它就好，自己從日期推算會在 UTC／台北的換日邊界出錯（每 240s 還會發一個無訊息空白 byte 維持 Bun `idleTimeout` 不砍 stream）
+  - 在 `/monitor` 網址後面加 `&heartbeat_secs=N` 可以自訂間隔（下限 240、上限 86400）。對 LLM 訂閱端來說每次心跳喚醒都是冷啟動——prompt cache 早就過期，整包 context 等於用寫入價重寫一次——所以間隔就是成本旋鈕，拉長一倍、閒置消耗就少一半。
 
 Bun 的 `idleTimeout` 把單次 `/poll` 等待上限壓在 ~250s，shim 自己 loop 即可。`/monitor` 則一直開著陪整個 session 生命週期，客戶端建議把 `curl -sN` 包在 reconnect loop 裡，daemon 重啟時能自我修復。
 

--- a/hook-session-start.ts
+++ b/hook-session-start.ts
@@ -48,16 +48,29 @@ is the dedicated wake path — no Stop-hook shim required:
 Each line on the stream becomes a notification:
   hello <alias>             -> baseline on connect, no action needed
   inbox <N> <alias>         -> unread waiting; call mcp__switchboard__read_messages
-  heartbeat <Asia/Taipei>   -> ~2-hr time tick (e.g. "heartbeat
-                               2026-04-24T13:38:25.000+08:00"); just a
-                               clock signal, no action needed (don't
-                               reply with "Heartbeat OK")
+  heartbeat <Asia/Taipei>   -> ~4-hr time tick (e.g. "heartbeat
+                               2026-04-24(五)T13:38:25.000+08:00" — the
+                               (X) after the date is the Taipei weekday,
+                               read it instead of working it out from the
+                               date yourself); just a clock signal, no
+                               action needed (don't reply "Heartbeat OK")
 
 The 240s TCP keep-alive is a single space byte without a newline, so the
 Monitor tool stays silent between heartbeat lines.
 
 The \`while :; do ... sleep 5; done\` wrapper auto-reconnects if the daemon
-restarts. Skip subscribing only if you're staying anonymous.`
+restarts. Skip subscribing only if you're staying anonymous.
+
+The heartbeat interval defaults to 4 hours and is yours to set — append
+\`&heartbeat_secs=N\` to the URL (clamped to 240..86400):
+
+  ...?cc_session_id=\${cc_session_id}&heartbeat_secs=7200   # every 2 hours
+
+Why the default is that long: every heartbeat wake is a cold start, because
+the prompt cache has expired by then, so the whole context is rewritten at
+cache-write price. The interval is therefore a direct cost knob — doubling it
+halves the idle burn. Sessions on a fixed cadence (scheduled reminders) should
+shorten it; sessions that are purely on standby can lengthen it.`
 
   return {
     hookSpecificOutput: {

--- a/server.ts
+++ b/server.ts
@@ -21,7 +21,7 @@ import type { Database } from 'bun:sqlite'
 import { openDatabase, createSession, findSessionById, findSessionByAlias, findSessionByCcSessionId, findSessionByClientSessionId, findAnySessionByClientSessionId, registerClientSession, unregisterClientSession, updateLastActivity, updateLastSeen, updateOwnerSeen, releaseSessionIfGeneration, insertMessage, insertBroadcast, fetchUnreadForRecipient, markMessagesRead, listAllSessions, recallMessage, countUnreadBySessionId, OwnershipConflictError } from './db'
 import { ConnectionRegistry, type PushCallback } from './connections'
 import { setAliasWithCollisionCheck, resolveTarget } from './aliases'
-import { toTaipeiISOString } from './time'
+import { toTaipeiISOString, toTaipeiHeartbeatString } from './time'
 import { startRetentionLoop } from './retention'
 import { UnreadWaiterRegistry } from './waiters'
 import type { BroadcastScope, ClientKind, SessionRow } from './types'
@@ -1003,7 +1003,7 @@ export async function startServer(opts: {
   }
 
   /**
-   * GET /monitor?cc_session_id=X
+   * GET /monitor?cc_session_id=X[&heartbeat_secs=N]
    *
    * Live chunked text stream for the Claude Code `Monitor` tool. The client
    * runs `curl -sN http://127.0.0.1:.../monitor?cc_session_id=...` as a
@@ -1015,9 +1015,10 @@ export async function startServer(opts: {
    * Idle keep-alive: every 240s we write a single space byte (no newline)
    * so the TCP connection stays warm against Bun's 255s idleTimeout, but
    * Monitor — which is line-buffered — does not emit a notification. Once
-   * every HEARTBEAT_LINE_EVERY (~2 hr) we *do* emit a real
-   * `heartbeat <iso-ts>` line, so subscribed sessions get an occasional
-   * time tick to ground them in real time without being woken every 4 min.
+   * every HEARTBEAT_LINE_EVERY (4 hr by default, see heartbeat_secs) we
+   * *do* emit a real `heartbeat <iso-ts>` line, so subscribed sessions get an
+   * occasional time tick to ground them in real time without being woken
+   * every 4 min. The line carries the Taipei weekday inline.
    * Earlier versions emitted the line every 240s, which woke every
    * connected session every four minutes for nothing.
    *
@@ -1079,11 +1080,31 @@ export async function startServer(opts: {
         // re-subscribe. On waiter timeout (no new messages within
         // HEARTBEAT_MS) write a silent keep-alive byte so Bun's idleTimeout
         // doesn't cut us and idle subscribers don't wake. Every
-        // HEARTBEAT_LINE_EVERY ticks (~2 hr) emit a visible heartbeat
+        // HEARTBEAT_LINE_EVERY ticks (4 hr by default) emit a visible heartbeat
         // line instead, so subscribed sessions get an occasional ground-truth
         // timestamp without being pinged every 4 min.
         const HEARTBEAT_MS = 240_000
-        const HEARTBEAT_LINE_EVERY = 30
+        // Default 4 hours, overridable per subscriber via heartbeat_secs.
+        // Every heartbeat wake is a cold start — the prompt cache has expired
+        // by then, so the whole context is re-written at cache-write price.
+        // That makes the interval a direct cost knob: doubling it halves the
+        // idle burn. Sessions that genuinely need a faster clock (scheduled
+        // reminders) pass a smaller value; pure standby sessions pass a larger
+        // one. Converted to whole 240s ticks, floored at 1 so a tiny value
+        // can't round to 0 and wake the session every tick.
+        const DEFAULT_HEARTBEAT_SECS = 14_400
+        const rawSecs = url.searchParams.get('heartbeat_secs')
+        let heartbeatSecs = DEFAULT_HEARTBEAT_SECS
+        if (rawSecs !== null) {
+          const n = Number(rawSecs)
+          if (Number.isFinite(n) && n > 0) {
+            heartbeatSecs = Math.min(86_400, Math.max(HEARTBEAT_MS / 1000, n))
+          }
+        }
+        const HEARTBEAT_LINE_EVERY = Math.max(
+          1,
+          Math.round(heartbeatSecs / (HEARTBEAT_MS / 1000)),
+        )
         let silentTicks = 0
         while (!req.signal.aborted) {
           await waiters.wait(
@@ -1103,7 +1124,10 @@ export async function startServer(opts: {
             // Asia/Taipei (+08:00) — matches the rest of the API surface
             // (DB stores UTC, human-facing lines / API responses are
             // converted via toTaipeiISOString — see CLAUDE.md "Time").
-            ok = write(`heartbeat ${toTaipeiISOString(new Date().toISOString())}`)
+            // The weekday is inlined so subscribers read it instead of
+            // deriving it from the date themselves, which goes wrong across
+            // the UTC/Taipei day boundary.
+            ok = write(`heartbeat ${toTaipeiHeartbeatString(new Date().toISOString())}`)
             silentTicks = 0
           } else {
             ok = writeKeepalive()

--- a/tests/time.test.ts
+++ b/tests/time.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'bun:test'
-import { nowUtc, toTaipeiISOString } from '../time'
+import { nowUtc, toTaipeiISOString, taipeiWeekdayZh, toTaipeiHeartbeatString } from '../time'
 
 test('nowUtc returns ISO 8601 UTC with Z suffix', () => {
   const s = nowUtc()
@@ -16,4 +16,25 @@ test('toTaipeiISOString converts UTC to +08:00', () => {
 test('toTaipeiISOString handles midnight rollover', () => {
   const utc = '2026-04-14T17:00:00.000Z'  // Taipei = next day 01:00
   expect(toTaipeiISOString(utc)).toBe('2026-04-15T01:00:00.000+08:00')
+})
+
+test('taipeiWeekdayZh returns single zh-TW weekday char', () => {
+  // 2026-07-04 is a Saturday in Taipei (and UTC).
+  expect(taipeiWeekdayZh('2026-07-04T06:00:00.000Z')).toBe('六')
+})
+
+test('taipeiWeekdayZh uses the Taipei date, not the UTC date', () => {
+  // 2026-07-03T17:00Z is still Friday in UTC but already Saturday 01:00
+  // in Taipei — the weekday must follow Taipei.
+  expect(taipeiWeekdayZh('2026-07-03T17:00:00.000Z')).toBe('六')
+})
+
+test('toTaipeiHeartbeatString inlines weekday after the date', () => {
+  const utc = '2026-07-04T06:02:11.152Z'  // Taipei 14:02 Saturday
+  expect(toTaipeiHeartbeatString(utc)).toBe('2026-07-04(六)T14:02:11.152+08:00')
+})
+
+test('toTaipeiHeartbeatString weekday follows Taipei across midnight rollover', () => {
+  const utc = '2026-07-03T17:00:00.000Z'  // Taipei = Sat 2026-07-04 01:00
+  expect(toTaipeiHeartbeatString(utc)).toBe('2026-07-04(六)T01:00:00.000+08:00')
 })

--- a/time.ts
+++ b/time.ts
@@ -16,3 +16,22 @@ export function toTaipeiISOString(utcIso: string): string {
   const g = (t: string) => parts.find(p => p.type === t)?.value ?? '00'
   return `${g('year')}-${g('month')}-${g('day')}T${g('hour')}:${g('minute')}:${g('second')}.${g('fractionalSecond')}+08:00`
 }
+
+// Taipei weekday as a single zh-TW character ("日一二三四五六").
+// Computed via Intl with an explicit timeZone — never derived by hand, so the
+// UTC/Taipei date boundary (a UTC evening is already "tomorrow" in Taipei)
+// can't produce an off-by-one weekday.
+export function taipeiWeekdayZh(utcIso: string): string {
+  return new Intl.DateTimeFormat('zh-TW', {
+    timeZone: 'Asia/Taipei',
+    weekday: 'narrow',
+  }).format(new Date(utcIso))
+}
+
+// Heartbeat line timestamp: Taipei ISO with the weekday inlined after the
+// date, e.g. "2026-07-04(六)T14:02:11.152+08:00". Only the /monitor heartbeat
+// line uses this — API responses stay on plain toTaipeiISOString.
+export function toTaipeiHeartbeatString(utcIso: string): string {
+  const iso = toTaipeiISOString(utcIso)
+  return iso.replace('T', `(${taipeiWeekdayZh(utcIso)})T`)
+}


### PR DESCRIPTION
家裡阿宇 8/25 推的分支，公司分機代開 PR。

- heartbeat 行改為 `2026-08-27(四)T16:00:00.000+08:00`，星期由 Intl 以 Asia/Taipei 計算，避免 UTC 日界線誤差
- 預設間隔 2h → 4h（每次 heartbeat 喚醒都是 prompt cache 過期後的冷啟動，間隔即成本旋鈕）
- `/monitor?...&heartbeat_secs=N` 可自訂（夾在 240..86400）；SessionStart hook 說明同步更新
- 測試：`bun test` 182 pass（含與另外兩支分支合併後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MHeUU6Q6z7MBbJJKvcVEi