### PR TITLE
文件：daemon 以系統服務常駐（Windows / Linux 範例）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ node_modules/
 bun.lockb
 daemon.out.log
 daemon.err.log
+logs/
+*.log
+switchboard-service.exe
+switchboard-service.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,12 @@ bun main.ts            # foreground
 powershell -File start-daemon.ps1  # detached background
 ```
 
+常駐部署掛成服務（設定範本 `switchboard-service.example.xml` / `switchboard.service.example`，
+安裝步驟見 README）。Windows 服務名 `switchboard-daemon`，**重啟要提權**；
+Linux 是 systemd user service，`systemctl --user restart switchboard` 不用提權。
+兩邊都要明寫 `SWITCHBOARD_DB` 與 `SWITCHBOARD_POLLER_STATE_DIR`——服務帳號的
+`os.homedir()` 不是你的家目錄，漏填會開到空資料庫。
+
 環境變數：
 - `SWITCHBOARD_PORT` — 預設 9876
 - `SWITCHBOARD_DB` — 預設 `<homedir>/.claude/switchboard.db`（用 `os.homedir()`，slash-normalized）

--- a/README.md
+++ b/README.md
@@ -74,13 +74,50 @@ Environment variables (all optional):
 | `SWITCHBOARD_DB` | `<homedir>/.claude/switchboard.db` | SQLite file path |
 | `SWITCHBOARD_POLLER_STATE_DIR` | `<homedir>/.claude` | Directory for poller state/lock files |
 
-### Auto-start on login (Windows scheduled task)
+### Run as a service (recommended)
+
+Running the daemon from a terminal ties its lifetime to that window. On Windows
+11 the tie is literal: Windows Terminal hosts every console program, so closing
+the window sends `CTRL_CLOSE` to the daemon as well. A service has no console.
+
+**Windows** — [WinSW](https://github.com/winsw/winsw/releases), saved next to the
+repo as `switchboard-service.exe`:
+
+```powershell
+Copy-Item switchboard-service.example.xml switchboard-service.xml
+# fill in the absolute paths inside it, then from an elevated shell:
+.\switchboard-service.exe install
+Start-Service switchboard-daemon
+```
+
+Restarting later also needs elevation: `Restart-Service switchboard-daemon`.
+
+**Linux** — systemd user service:
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp switchboard.service.example ~/.config/systemd/user/switchboard.service
+systemctl --user daemon-reload
+systemctl --user enable --now switchboard
+loginctl enable-linger "$USER"   # survive reboots without logging in first
+```
+
+Logs go to the journal (`journalctl --user -u switchboard -f`) and restarting
+needs no elevation: `systemctl --user restart switchboard`.
+
+Both templates spell out `SWITCHBOARD_DB` and `SWITCHBOARD_POLLER_STATE_DIR`
+instead of leaning on `os.homedir()`, because a service account's home is not
+yours — omit them and the daemon quietly opens an empty database.
+
+### Auto-start on login (Windows scheduled task, legacy)
 
 ```powershell
 powershell -File install-task.ps1
 ```
 
-Registers the scheduled task `Switchboard MCP Daemon`, which runs `start-daemon.ps1` at user logon.
+Registers the scheduled task `Switchboard MCP Daemon`, which runs
+`start-daemon.ps1` at user logon. Superseded by the service above — see the
+console-close caveat.
 
 ## Wire up Claude Code
 
@@ -347,8 +384,10 @@ aliases.ts               # alias collision handling + target resolution
 poller.ts                # legacy bun-based Stop-hook poller (fallback)
 poller-shim.ps1          # PowerShell Stop-hook shim (default)
 hook-session-start.ts    # SessionStart hook that injects cc_session_id
-install-task.ps1         # registers the Windows scheduled task
+install-task.ps1         # registers the Windows scheduled task (legacy)
 start-daemon.ps1         # launches the daemon detached in the background
+switchboard-service.example.xml  # WinSW template for the Windows service
+switchboard.service.example      # systemd user-service template for Linux
 tests/                   # bun:test suites
 ```
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -74,13 +74,49 @@ powershell -File start-daemon.ps1
 | `SWITCHBOARD_DB` | `<homedir>/.claude/switchboard.db` | SQLite 檔案路徑 |
 | `SWITCHBOARD_POLLER_STATE_DIR` | `<homedir>/.claude` | Poller state/lock 檔案目錄 |
 
-### 登入自動啟動（Windows Scheduled Task）
+### 掛成服務執行（建議）
+
+從終端機跑 daemon 等於把它的壽命綁在那個視窗上。Windows 11 上這件事是字面意義的：
+Windows Terminal 托管每一個主控台程式，視窗一關就把 `CTRL_CLOSE` 一起發給 daemon。
+服務沒有主控台，不受影響。
+
+**Windows** — 用 [WinSW](https://github.com/winsw/winsw/releases)，放在 repo 旁邊
+命名為 `switchboard-service.exe`：
+
+```powershell
+Copy-Item switchboard-service.example.xml switchboard-service.xml
+# 把裡面的絕對路徑填好，然後在提權的終端機執行：
+.\switchboard-service.exe install
+Start-Service switchboard-daemon
+```
+
+之後要重啟同樣需要提權：`Restart-Service switchboard-daemon`。
+
+**Linux** — systemd user service：
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp switchboard.service.example ~/.config/systemd/user/switchboard.service
+systemctl --user daemon-reload
+systemctl --user enable --now switchboard
+loginctl enable-linger "$USER"   # 沒登入也要能撐過重開機就加這行
+```
+
+Log 走 journal（`journalctl --user -u switchboard -f`），重啟不需要提權：
+`systemctl --user restart switchboard`。
+
+兩份範本都把 `SWITCHBOARD_DB` 和 `SWITCHBOARD_POLLER_STATE_DIR` 寫死，而不是靠
+`os.homedir()`——服務帳號的家目錄不是你的家目錄，漏填的話 daemon 會無聲地開一個
+空資料庫。
+
+### 登入自動啟動（Windows Scheduled Task，舊做法）
 
 ```powershell
 powershell -File install-task.ps1
 ```
 
 會註冊一個 `Switchboard MCP Daemon` 排程，使用者登入時自動執行 `start-daemon.ps1`。
+已被上面的服務取代——原因見前一段的主控台關閉問題。
 
 ## 接 Claude Code
 
@@ -326,8 +362,10 @@ aliases.ts               # alias 碰撞處理 + 目標解析
 poller.ts                # 舊版 bun 實作的 Stop-hook poller（fallback）
 poller-shim.ps1          # PowerShell Stop-hook shim（預設）
 hook-session-start.ts    # SessionStart hook，注入 cc_session_id
-install-task.ps1         # 註冊 Windows 排程
+install-task.ps1         # 註冊 Windows 排程（舊做法）
 start-daemon.ps1         # 背景啟動 daemon
+switchboard-service.example.xml  # Windows 服務的 WinSW 設定範本
+switchboard.service.example      # Linux 的 systemd user service 範本
 tests/                   # bun:test 測試集
 ```
 

--- a/switchboard-service.example.xml
+++ b/switchboard-service.example.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  WinSW configuration for running the switchboard daemon as a Windows service.
+  Copy this to switchboard-service.xml and fill in the absolute paths below.
+
+  Why a service rather than a scheduled task: once Windows 11 sets the default
+  terminal application to Windows Terminal, every console program — including
+  the powershell.exe a scheduled task launches — is hosted by that terminal.
+  Closing the window sends CTRL_CLOSE to everything it hosts, so the daemon
+  dies with it and the log ends at a lone ^C. A service is not attached to any
+  console, so the window lifecycle cannot touch it.
+
+  <onfailure> is the Windows service recovery mechanism, which also removes the
+  need for a hand-written supervisor loop and its single point of failure: the
+  supervisor process itself getting killed.
+-->
+<service>
+  <id>switchboard-daemon</id>
+  <name>Switchboard MCP Daemon</name>
+  <description>Local MCP switchboard daemon for Claude Code session communication (loopback only, port 9876)</description>
+
+  <!-- Absolute paths are required: the service runs as LocalSystem, whose PATH
+       is not yours, so a bare "bun" will not resolve. -->
+  <executable>C:\Users\YOUR_USER\.bun\bin\bun.exe</executable>
+  <arguments>main.ts</arguments>
+  <workingdirectory>C:\path\to\switchboard</workingdirectory>
+
+  <startmode>Automatic</startmode>
+
+  <!-- Restart after a crash; forget the failure count once an hour passes clean -->
+  <onfailure action="restart" delay="10 sec"/>
+  <resetfailure>1 hour</resetfailure>
+  <stoptimeout>15 sec</stoptimeout>
+
+  <logpath>C:\path\to\switchboard\logs</logpath>
+  <log mode="roll-by-size">
+    <sizeThreshold>10240</sizeThreshold>
+    <keepFiles>8</keepFiles>
+  </log>
+
+  <!--
+    Both paths must be spelled out. Under the service account os.homedir()
+    resolves to C:\Windows\System32\config\systemprofile, which would open an
+    empty database — every registration and every stored message would look
+    like it had vanished.
+  -->
+  <env name="SWITCHBOARD_DB" value="C:/Users/YOUR_USER/.claude/switchboard.db"/>
+  <env name="SWITCHBOARD_POLLER_STATE_DIR" value="C:/Users/YOUR_USER/.claude"/>
+</service>

--- a/switchboard.service.example
+++ b/switchboard.service.example
@@ -1,0 +1,40 @@
+# systemd user service for the switchboard daemon.
+#
+# Install:
+#   mkdir -p ~/.config/systemd/user
+#   cp switchboard.service.example ~/.config/systemd/user/switchboard.service
+#   # adjust WorkingDirectory below if the repo does not live at ~/switchboard
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now switchboard
+#
+# A *user* service is deliberate. The daemon binds loopback only and keeps its
+# database under ~/.claude, so it wants your identity and your home directory.
+# A system service would resolve os.homedir() to the service account and open an
+# empty database instead — the Windows side of this repo hit exactly that.
+#
+# One consequence worth knowing: user services stop when you log out and do not
+# come back until the next login. To keep the daemon running across reboots
+# without logging in, enable lingering once:
+#
+#   loginctl enable-linger "$USER"
+#
+# Logs go to the journal:  journalctl --user -u switchboard -f
+
+[Unit]
+Description=Switchboard MCP daemon for Claude Code sessions
+Documentation=https://github.com/wuguofish/Switchboard
+After=network.target
+
+[Service]
+Type=simple
+# systemd does not inherit your shell PATH, so bun needs an absolute path.
+# %h expands to the home directory of the user the service runs as.
+ExecStart=%h/.bun/bin/bun main.ts
+WorkingDirectory=%h/switchboard
+Restart=always
+RestartSec=10s
+Environment=SWITCHBOARD_DB=%h/.claude/switchboard.db
+Environment=SWITCHBOARD_POLLER_STATE_DIR=%h/.claude
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
家裡阿宇 8/25 推的分支，公司分機代開 PR。純文件與範例檔：systemd user unit 範例、Windows 服務 XML、README（en/zh-TW）、CLAUDE.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MHeUU6Q6z7MBbJJKvcVEi